### PR TITLE
Mock assertions

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -20,6 +20,7 @@ The aim of this project is to port Spock to Python while maintaining the origina
 * Write detailed specifications with clear distinction.
 * Auto discovery of specifications.
 * Write data-driven specifications.
+* Pretty mock behavior assertion.
 * See fancy detailed assertion failure reports.
 
 == Examples
@@ -102,17 +103,6 @@ class MySpec(Specification):
             a == 2
 ----
 
-[source,bash]
-----
-$ nimoy
-
-my_feature_method (builtins.MySpec) ... ok
-
-----------------------------------------------------------------------
-Ran 1 test in 0.000s
-
-OK
-----
 
 === Data-driven Specification
 
@@ -139,15 +129,32 @@ class MySpec(Specification):
             2          | 20         | 40
 ----
 
-[source,bash]
+
+=== Pretty Mock Assertions
+
+When using `unittest` Mocks you can write pretty assertions in the `then` block.
+Mock assertion expressions are written like a mathematical expression with the format of `[NUMBER_OF_INVOCATIONS] * [INVOCATION_TARGET]`.
+
+`[NUMBER_OF_INVOCATIONS]` may be a wildcard when filled in with `\_`.
+Invocation target arguments may also be wildcarded by placing `_`. For example, `class.method(_, 3)`.
+
+.pretty_mock_assertions.py
+[source,python]
 ----
-$ nimoy
-my_feature_method (builtins.MySpec) ... ok
+from unittest import mock
+from nimoy.specification import Specification
 
-----------------------------------------------------------------------
-Ran 1 test in 0.000s
+class MySpec(Specification):
 
-OK
+    def my_feature_method(self):
+        with setup:
+            the_mock = mock.Mock()
+
+        with when:
+            the_mock.some_method('abcd', True)
+
+        with then:
+            1 * the_mock.some_method('abcd', True)
 ----
 
 === More great features to come!

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Features
 - Write detailed specifications with clear distinction.
 - Auto discovery of specifications.
 - Write data-driven specifications.
+- Pretty mock behavior assertion.
 - See fancy detailed assertion failure reports.
 
 License

--- a/nimoy/assertions/mocks.py
+++ b/nimoy/assertions/mocks.py
@@ -1,0 +1,17 @@
+class MockAssertions:
+    def assert_mock(self, number_of_invocations, mock, method, *args):
+        if not hasattr(mock, method) and number_of_invocations > 0:
+            raise AssertionError(method + " was never invoked") from None
+
+        mocked_method = getattr(mock, method)
+        if (number_of_invocations >= 0) and (mocked_method.call_count != number_of_invocations):
+            raise AssertionError(
+                method + " was to be invoked " + str(number_of_invocations) + " times but was invoked " + str(
+                    mocked_method.call_count)) from None
+
+        for index, value in enumerate(mocked_method.call_args[0]):
+            expected_value = args[index]
+            if expected_value != '__nimoy_argument_wildcard' and expected_value != value:
+                raise AssertionError(
+                    method + " expected argument " + str(expected_value) + " but was invoked with " + str(
+                        value)) from None

--- a/nimoy/assertions/mocks.py
+++ b/nimoy/assertions/mocks.py
@@ -9,8 +9,7 @@ class MockAssertions:
                 method + " was to be invoked " + str(number_of_invocations) + " times but was invoked " + str(
                     mocked_method.call_count)) from None
 
-        for index, value in enumerate(mocked_method.call_args[0]):
-            expected_value = args[index]
+        for value, expected_value in zip(mocked_method.call_args[0], args):
             if expected_value != '__nimoy_argument_wildcard' and expected_value != value:
                 raise AssertionError(
                     method + " expected argument " + str(expected_value) + " but was invoked with " + str(

--- a/nimoy/ast_tools/expression_transformer.py
+++ b/nimoy/ast_tools/expression_transformer.py
@@ -41,3 +41,42 @@ class ComparisonExpressionTransformer(ast.NodeTransformer):
             keywords=[]
         )
         return expression_node
+
+
+class MockAssertionTransformer(ast.NodeTransformer):
+    def visit_Expr(self, expression_node):
+        value = expression_node.value
+        if not isinstance(value, _ast.BinOp) or not isinstance(value.op, _ast.Mult) or not isinstance(value.right,
+                                                                                                      _ast.Call):
+            return expression_node
+
+        number_of_invocations = value.left
+        if MockAssertionTransformer._value_is_a_wildcard(number_of_invocations):
+            number_of_invocations = _ast.Num(n=-1)
+        target_mock = value.right.func.value
+        target_method = _ast.Str(s=value.right.func.attr)
+
+        list_of_arguments = [MockAssertionTransformer._transform_arg_if_wildcard(x) for x in value.right.args]
+        spread_list_of_arguments = _ast.Starred(value=_ast.List(elts=list_of_arguments, ctx=_ast.Load()),
+                                                ctx=_ast.Load())
+        expression_node.value = _ast.Call(
+            func=_ast.Attribute(
+                value=_ast.Name(id='self', ctx=_ast.Load()),
+                attr='_assert_mock',
+                ctx=_ast.Load()
+            ),
+            args=[number_of_invocations, target_mock, target_method, spread_list_of_arguments],
+            keywords=[]
+        )
+        return expression_node
+
+    @staticmethod
+    def _value_is_a_wildcard(value):
+        return isinstance(value, _ast.Name) and value.id == '_'
+
+    @staticmethod
+    def _transform_arg_if_wildcard(arg):
+        if MockAssertionTransformer._value_is_a_wildcard(arg):
+            return _ast.Str(s='__nimoy_argument_wildcard')
+
+        return arg

--- a/nimoy/ast_tools/feature_blocks.py
+++ b/nimoy/ast_tools/feature_blocks.py
@@ -2,6 +2,7 @@ import ast
 import copy
 import _ast
 from nimoy.ast_tools.expression_transformer import ComparisonExpressionTransformer
+from nimoy.ast_tools.expression_transformer import MockAssertionTransformer
 from nimoy.runner.exceptions import InvalidFeatureBlockException
 
 SETUP = 'setup'
@@ -161,6 +162,9 @@ class FeatureBlockTransformer(ast.NodeTransformer):
                 FeatureBlockTransformer._replace_with_block_context(with_node, block_type)
                 if block_type in [THEN, EXPECT]:
                     ComparisonExpressionTransformer().visit(with_node)
+
+                if block_type == THEN:
+                    MockAssertionTransformer().visit(with_node)
                 return with_node
 
             where_function = self._replace_where_block_with_function(with_node)

--- a/nimoy/specification.py
+++ b/nimoy/specification.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import copy
 from nimoy.context.feature_block_context import FeatureBlock
 from nimoy.compare.internal import Compare
+from nimoy.assertions.mocks import MockAssertions
 
 
 class DataDrivenSpecification(type):
@@ -56,3 +57,6 @@ class Specification(TestCase, metaclass=DataDrivenSpecification):
 
     def _compare(self, left, right, comparison_type_name):
         Compare().compare(left, right, comparison_type_name)
+
+    def _assert_mock(self, number_of_invocations, mock, method, *args):
+        MockAssertions().assert_mock(number_of_invocations, mock, method, *args)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     entry_points={'console_scripts': ['nimoy = nimoy.main:main']},
     classifiers=classifiers,
     keywords="test unittest specification",
-    packages=['nimoy', 'nimoy.ast_tools', 'nimoy.context', 'nimoy.runner', 'nimoy.compare'],
+    packages=['nimoy', 'nimoy.assertions', 'nimoy.ast_tools', 'nimoy.context', 'nimoy.runner', 'nimoy.compare'],
     install_requires=['pyhamcrest==1.9'],
 
 )

--- a/tests/nimoy/integration/test_mock_assertions.py
+++ b/tests/nimoy/integration/test_mock_assertions.py
@@ -1,0 +1,130 @@
+from tests.nimoy.integration.base_integration_test import BaseIntegrationTest
+
+
+class TestMockAssertions(BaseIntegrationTest):
+    def test_successful_assertion(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method()
+        with then:
+            1 * the_mock.some_method()
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertTrue(result.wasSuccessful())
+
+    def test_failed_assertion(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method()
+        with then:
+            1 * the_mock.some_method()
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertFalse(result.wasSuccessful())
+
+    def test_successful_assertion_with_arguments(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method('abcd', True)
+        with then:
+            1 * the_mock.some_method('abcd', True)
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertTrue(result.wasSuccessful())
+
+    def test_failed_assertion_with_arguments(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method('abcd', True)
+        with then:
+            1 * the_mock.some_method('abcd', False)
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertFalse(result.wasSuccessful())
+
+    def test_successful_assertion_with_wild_card_invocation_count(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method('abcd', True)
+        with then:
+            _ * the_mock.some_method('abcd', True)
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertTrue(result.wasSuccessful())
+
+    def test_successful_assertion_with_wild_card_parameter(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method('abcd', True)
+        with then:
+            1 * the_mock.some_method(_, True)
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertTrue(result.wasSuccessful())
+
+    def test_successful_assertion_with_reference_parameter(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            a = 3
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method(3, True)
+        with then:
+            1 * the_mock.some_method(a, True)
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertTrue(result.wasSuccessful())

--- a/tests/nimoy/integration/test_mock_assertions.py
+++ b/tests/nimoy/integration/test_mock_assertions.py
@@ -20,7 +20,7 @@ class JimbobSpec(Specification):
         result = self._run_spec_contents(spec_contents)
         self.assertTrue(result.wasSuccessful())
 
-    def test_failed_assertion(self):
+    def test_failed_invocation_count_assertion(self):
         spec_contents = """from unittest import mock
 from nimoy.specification import Specification
 
@@ -32,7 +32,7 @@ class JimbobSpec(Specification):
         with when:
             the_mock.some_method()
         with then:
-            1 * the_mock.some_method()
+            0 * the_mock.some_method()
         """
 
         result = self._run_spec_contents(spec_contents)
@@ -56,7 +56,25 @@ class JimbobSpec(Specification):
         result = self._run_spec_contents(spec_contents)
         self.assertTrue(result.wasSuccessful())
 
-    def test_failed_assertion_with_arguments(self):
+    def test_failed_invocation_count_assertion_with_arguments(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method('abcd', True)
+        with then:
+            0 * the_mock.some_method('abcd', False)
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertFalse(result.wasSuccessful())
+
+    def test_failed_argument_assertion(self):
         spec_contents = """from unittest import mock
 from nimoy.specification import Specification
 
@@ -69,6 +87,24 @@ class JimbobSpec(Specification):
             the_mock.some_method('abcd', True)
         with then:
             1 * the_mock.some_method('abcd', False)
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertFalse(result.wasSuccessful())
+
+    def test_failed_argument_assertion_with_wildcard(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method('abcd', True)
+        with then:
+            1 * the_mock.some_method(_, False)
         """
 
         result = self._run_spec_contents(spec_contents)
@@ -92,7 +128,7 @@ class JimbobSpec(Specification):
         result = self._run_spec_contents(spec_contents)
         self.assertTrue(result.wasSuccessful())
 
-    def test_successful_assertion_with_wild_card_parameter(self):
+    def test_successful_assertion_with_wild_card_argument(self):
         spec_contents = """from unittest import mock
 from nimoy.specification import Specification
 
@@ -110,7 +146,7 @@ class JimbobSpec(Specification):
         result = self._run_spec_contents(spec_contents)
         self.assertTrue(result.wasSuccessful())
 
-    def test_successful_assertion_with_reference_parameter(self):
+    def test_successful_assertion_with_reference_argument(self):
         spec_contents = """from unittest import mock
 from nimoy.specification import Specification
 

--- a/tests/nimoy/integration/test_mock_assertions.py
+++ b/tests/nimoy/integration/test_mock_assertions.py
@@ -1,3 +1,4 @@
+import unittest
 from tests.nimoy.integration.base_integration_test import BaseIntegrationTest
 
 
@@ -50,6 +51,29 @@ class JimbobSpec(Specification):
         with when:
             the_mock.some_method('abcd', True)
         with then:
+            1 * the_mock.some_method('abcd', True)
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertTrue(result.wasSuccessful())
+
+    @unittest.skip("TODO: Implement spread mock assertions")
+    def test_successful_spread_assertion_with_arguments(self):
+        spec_contents = """from unittest import mock
+from nimoy.specification import Specification
+
+
+class JimbobSpec(Specification):
+    def test(self):
+        with setup:
+            the_mock = mock.Mock()
+        with when:
+            the_mock.some_method('abcd', True)
+            the_mock.some_method('efgh', False)
+            the_mock.some_method('abcd', True)
+        with then:
+            1 * the_mock.some_method('abcd', True)
+            1 * the_mock.some_method('efgh', False)
             1 * the_mock.some_method('abcd', True)
         """
 


### PR DESCRIPTION
Assertions are written like a mathematical expression with the format of `[NUMBER_OF_INVOCATIONS] * [INVOCATION_TARGET]`.
Where `[NUMBER_OF_INVOCATIONS]` may be a wildcard when filled in with `_`.
Invocation target parameters may also be wildcarded by placing `_`. For example `class.method(_, 3)`