### PR TITLE
Optionally specifiy the injected arguments in the feature signature

### DIFF
--- a/nimoy/ast_tools/features.py
+++ b/nimoy/ast_tools/features.py
@@ -18,7 +18,11 @@ class FeatureRegistrationTransformer(ast.NodeTransformer):
 
         feature_variables = self.spec_metadata.feature_variables.get(feature_name)
         if feature_variables:
+            existing_arg_names = [existing_arg.arg for existing_arg in feature_node.args.args]
+
             for feature_variable in feature_variables:
+                if feature_variable in existing_arg_names:
+                    continue
                 feature_node.args.args.append(_ast.arg(arg=feature_variable))
                 feature_node.args.defaults.append(_ast.NameConstant(value=None))
 

--- a/tests/nimoy/integration/test_where_block.py
+++ b/tests/nimoy/integration/test_where_block.py
@@ -21,6 +21,25 @@ class JimbobSpec(Specification):
         result = self._run_spec_contents(spec_contents)
         self.assertTrue(result.wasSuccessful())
 
+    def test_single_variable_with_explicit_declaration(self):
+        spec_contents = """from nimoy.specification import Specification
+        
+class JimbobSpec(Specification):
+    
+    def test(self, value_of_a):
+        with given:
+            a = value_of_a
+            
+        with expect:
+            (a % 2) == 0
+        
+        with where:
+            value_of_a = [2, 4, 6, 8]
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertTrue(result.wasSuccessful())
+
     def test_single_variable_with_generator(self):
         spec_contents = """from nimoy.specification import Specification
         
@@ -362,6 +381,28 @@ class JimbobSpec(Specification):
             2          | 1          | 2
             4          | 3          | 12
             6          | 5          | 30
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertTrue(result.wasSuccessful())
+
+    def test_matrix_form_with_explicit_declaration(self):
+        spec_contents = """from nimoy.specification import Specification
+        
+class JimbobSpec(Specification):
+    
+    def test(self, value_of_a, value_of_b, expected_value):
+        with given:
+            a = value_of_a
+            b = value_of_b
+            
+        with expect:
+            (a * b) == expected_value
+        
+        with where:
+            value_of_a | value_of_b | expected_value
+            2          | 1          | 2
+            
         """
 
         result = self._run_spec_contents(spec_contents)


### PR DESCRIPTION
Following feedback from demoing Nimoy at the local meetup: Trying to make Nimoy a bit more "Pythonic" by adding the ability to specify the arguments that were inject by the `where` block in the method signature rather than them being injected implicitly. This is optional and we are still not required to specify arguments