### PR TITLE
Features variable declaration as strings

### DIFF
--- a/nimoy/ast_tools/feature_blocks.py
+++ b/nimoy/ast_tools/feature_blocks.py
@@ -86,8 +86,14 @@ class WhereBlockFunctions:
         if isinstance(binary_op_node.left, _ast.BinOp):
             WhereBlockFunctions._collect_variable_names_recursively(binary_op_node.left, variable_names)
         else:
-            variable_names.append(binary_op_node.left.id)
-        variable_names.append(binary_op_node.right.id)
+            variable_names.append(WhereBlockFunctions._get_variable_name(binary_op_node.left))
+        variable_names.append(WhereBlockFunctions._get_variable_name(binary_op_node.right))
+
+    @staticmethod
+    def _get_variable_name(variable_object):
+        if hasattr(variable_object, 's'):
+            return variable_object.s
+        return variable_object.id
 
     @staticmethod
     def _collect_variable_values_recursively(binary_op_node, variable_values):

--- a/tests/nimoy/integration/test_where_block.py
+++ b/tests/nimoy/integration/test_where_block.py
@@ -386,6 +386,29 @@ class JimbobSpec(Specification):
         result = self._run_spec_contents(spec_contents)
         self.assertTrue(result.wasSuccessful())
 
+    def test_stringy_matrix_form_variable_names(self):
+        spec_contents = """from nimoy.specification import Specification
+        
+class JimbobSpec(Specification):
+    
+    def test(self):
+        with given:
+            a = value_of_a
+            b = value_of_b
+            
+        with expect:
+            (a * b) == expected_value
+        
+        with where:
+            "value_of_a" | "value_of_b" | "expected_value"
+            2            | 1            | 2
+            4            | 3            | 12
+            6            | 5            | 30
+        """
+
+        result = self._run_spec_contents(spec_contents)
+        self.assertTrue(result.wasSuccessful())
+
     def test_matrix_form_with_explicit_declaration(self):
         spec_contents = """from nimoy.specification import Specification
         


### PR DESCRIPTION
Following feedback from demoing Nimoy at the local meetup: Trying to make Nimoy a bit more "Pythonic" by adding the ability to specify the names of the arguments within the `where` block as strings rather that "dangling" variables. This is of course optional