### PR TITLE
Add installation and package name hint

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -23,6 +23,13 @@ The aim of this project is to port Spock to Python while maintaining the origina
 * Pretty mock behavior assertion.
 * See fancy detailed assertion failure reports.
 
+== Install
+
+[source,bash]
+----
+pip install nimoy-framework
+----
+
 == Examples
 
 Nimoy will pick up on any module ending with `_spec.py` and will treat any class that ends with the word `Spec` as a Specification class.


### PR DESCRIPTION
Hi,

I did some research around python testing frameworks because I'd like to get https://eno-lang.org/python/ bullet-proof and production ready in the next months, and this (coming from jest and rspec) hands down looks like the best thing out there, even if somewhat unclear how it's progressing :) So ... looking forward to seeing more!

I know it sounds ridiculous but for me this almost ended the trial prematurely: No installation instructions, which wouldn't matter that much if `pip install nimoy` would do the trick, but my expectation was not fulfilled and you can imagine that some minutes of puzzlement ensued ;) I'd very much recommend to give a hint on the package name somewhere, pick it up from my PR, put it somewhere else, don't mind, just put it somewhere I'd suggest. :)

I'll add a small PS.: If nimoy handles this out of the box - https://stackoverflow.com/questions/1896918/running-unittest-with-typical-test-directory-structure - and I am somehow missing how, it would be great if it were included in the documentation, because this was my second pain point, I hacked around it now somehow but this would be super awesome if ready and there out of the box (and documented ;)).

Thanks so much, LLAP. :)
Simon