### PR TITLE
Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ matrix:
   include:
     - python: 3.6
     - python: 3.7
-      dist: xenial
-      sudo: true
+    - python: 3.8
 
 install:
   - pip install -U setuptools pip pipenv

--- a/nimoy/ast_tools/ast_3_7.py
+++ b/nimoy/ast_tools/ast_3_7.py
@@ -1,0 +1,24 @@
+import _ast
+
+
+class AST:
+
+    @staticmethod
+    def str(s):
+        return _ast.Str(s)
+
+    @staticmethod
+    def name_constant(value=None):
+        return _ast.NameConstant(value=value)
+
+    @staticmethod
+    def args(args=None):
+        return _ast.arguments(
+            args=args,
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[])
+
+    @staticmethod
+    def num(n=None):
+        return _ast.Num(n=n)

--- a/nimoy/ast_tools/ast_3_8.py
+++ b/nimoy/ast_tools/ast_3_8.py
@@ -1,0 +1,26 @@
+import _ast
+import ast
+
+
+class AST:
+
+    @staticmethod
+    def str(s):
+        return ast.Str(s)
+
+    @staticmethod
+    def name_constant(value=None):
+        return ast.NameConstant(value=value)
+
+    @staticmethod
+    def args(args=None):
+        return _ast.arguments(
+            args=args,
+            posonlyargs=[],
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[])
+
+    @staticmethod
+    def num(n=None):
+        return ast.Num(n=n)

--- a/nimoy/ast_tools/ast_proxy.py
+++ b/nimoy/ast_tools/ast_proxy.py
@@ -1,0 +1,23 @@
+import sys
+
+IS_3_8 = sys.version_info >= (3, 8)
+if IS_3_8:
+    from .ast_3_8 import AST
+else:
+    from .ast_3_7 import AST
+
+
+def ast_str(s):
+    return AST.str(s)
+
+
+def ast_name_constant(value=None):
+    return AST.name_constant(value)
+
+
+def ast_args(args=None):
+    return AST.args(args)
+
+
+def ast_num(n=None):
+    return AST.num(n)

--- a/nimoy/ast_tools/expression_transformer.py
+++ b/nimoy/ast_tools/expression_transformer.py
@@ -1,5 +1,7 @@
-import ast
 import _ast
+import ast
+
+from nimoy.ast_tools import ast_proxy
 from nimoy.compare.types import Types
 
 
@@ -47,7 +49,7 @@ class ComparisonExpressionTransformer(ast.NodeTransformer):
                 attr='_compare',
                 ctx=_ast.Load()
             ),
-            args=[left_value, right_value, _ast.Str(s=internal_comparison_type.name)],
+            args=[left_value, right_value, ast_proxy.ast_str(s=internal_comparison_type.name)],
             keywords=[]
         )
         return expression_node
@@ -103,9 +105,9 @@ class MockAssertionTransformer(ast.NodeTransformer):
 
         number_of_invocations = value.left
         if MockAssertionTransformer._value_is_a_wildcard(number_of_invocations):
-            number_of_invocations = _ast.Num(n=-1)
+            number_of_invocations = ast_proxy.ast_num(n=-1)
         target_mock = value.right.func.value
-        target_method = _ast.Str(s=value.right.func.attr)
+        target_method = ast_proxy.ast_str(s=value.right.func.attr)
 
         list_of_arguments = [MockAssertionTransformer._transform_arg_if_wildcard(x) for x in value.right.args]
         spread_list_of_arguments = _ast.Starred(value=_ast.List(elts=list_of_arguments, ctx=_ast.Load()),
@@ -128,6 +130,6 @@ class MockAssertionTransformer(ast.NodeTransformer):
     @staticmethod
     def _transform_arg_if_wildcard(arg):
         if MockAssertionTransformer._value_is_a_wildcard(arg):
-            return _ast.Str(s='__nimoy_argument_wildcard')
+            return ast_proxy.ast_str(s='__nimoy_argument_wildcard')
 
         return arg

--- a/nimoy/ast_tools/feature_blocks.py
+++ b/nimoy/ast_tools/feature_blocks.py
@@ -1,6 +1,8 @@
+import _ast
 import ast
 import copy
-import _ast
+
+from nimoy.ast_tools import ast_proxy
 from nimoy.ast_tools.expression_transformer import ComparisonExpressionTransformer, MockAssertionTransformer, \
     ThrownExpressionTransformer, MockBehaviorExpressionTransformer
 from nimoy.runner.exceptions import InvalidFeatureBlockException
@@ -40,7 +42,7 @@ class WhereBlockFunctions:
                     targets=[
                         _ast.Subscript(
                             value=_ast.Name(id='injectable_values', ctx=_ast.Load()),
-                            slice=_ast.Index(value=_ast.Str(s=variable_name)),
+                            slice=_ast.Index(value=ast_proxy.ast_str(s=variable_name)),
                             ctx=_ast.Store()
                         )
                     ],
@@ -61,7 +63,7 @@ class WhereBlockFunctions:
                     targets=[
                         _ast.Subscript(
                             value=_ast.Name(id='injectable_values', ctx=_ast.Load()),
-                            slice=_ast.Index(value=_ast.Str(s=variable_name)),
+                            slice=_ast.Index(value=ast_proxy.ast_str(s=variable_name)),
                             ctx=_ast.Store()
                         )
                     ],
@@ -200,16 +202,11 @@ class FeatureBlockTransformer(ast.NodeTransformer):
     def _replace_with_block_context(with_node, block_type):
         with_node.items[0].context_expr = _ast.Call(
             func=_ast.Attribute(value=_ast.Name(id='self', ctx=_ast.Load()), attr='_feature_block_context',
-                                ctx=_ast.Load()), args=[_ast.Str(s=block_type)], keywords=[])
+                                ctx=_ast.Load()), args=[ast_proxy.ast_str(s=block_type)], keywords=[])
 
     def _replace_where_block_with_function(self, with_node):
         return _ast.FunctionDef(name=self.feature_name + '_where',
-                                args=_ast.arguments(
-                                    args=[_ast.arg(arg='self'), _ast.arg(arg='injectable_values')],
-                                    kwonlyargs=[],
-                                    kw_defaults=[],
-                                    defaults=[]
-                                ),
+                                args=ast_proxy.ast_args([_ast.arg(arg='self'), _ast.arg(arg='injectable_values')]),
                                 body=copy.deepcopy(with_node.body),
                                 decorator_list=[],
                                 returns=None)

--- a/nimoy/ast_tools/features.py
+++ b/nimoy/ast_tools/features.py
@@ -1,7 +1,9 @@
-import ast
 import _ast
-from nimoy.ast_tools.feature_blocks import FeatureBlockTransformer
+import ast
+
+from nimoy.ast_tools import ast_proxy
 from nimoy.ast_tools.feature_blocks import FeatureBlockRuleEnforcer
+from nimoy.ast_tools.feature_blocks import FeatureBlockTransformer
 
 
 class FeatureRegistrationTransformer(ast.NodeTransformer):
@@ -24,7 +26,7 @@ class FeatureRegistrationTransformer(ast.NodeTransformer):
                 if feature_variable in existing_arg_names:
                     continue
                 feature_node.args.args.append(_ast.arg(arg=feature_variable))
-                feature_node.args.defaults.append(_ast.NameConstant(value=None))
+                feature_node.args.defaults.append(ast_proxy.ast_name_constant(value=None))
 
         if self._feature_has_a_where_function(feature_name):
             self._remove_where_function_from_node(feature_name, feature_node)


### PR DESCRIPTION
The AST API broke between 3.7 to 3.8 so I've added a proxy class that invokes the correct methods whenever there's a divergence