### PR TITLE
Adding the ability to specify which spec or feature to run

### DIFF
--- a/nimoy/ast_tools/ast_chain.py
+++ b/nimoy/ast_tools/ast_chain.py
@@ -1,8 +1,8 @@
 from nimoy.ast_tools.specs import SpecTransformer
 
 
-def apply(node):
+def apply(spec_location, node):
     spec_metadata = []
 
-    SpecTransformer(spec_metadata).visit(node)
+    SpecTransformer(spec_location, spec_metadata).visit(node)
     return spec_metadata

--- a/nimoy/ast_tools/features.py
+++ b/nimoy/ast_tools/features.py
@@ -54,4 +54,4 @@ class FeatureRegistrationTransformer(ast.NodeTransformer):
     @staticmethod
     def _skip_feature(feature_node):
         decorators = feature_node.decorator_list
-        return any((hasattr(decorator, 'attr') and decorator.attr is 'skip') for decorator in decorators)
+        return any((hasattr(decorator, 'attr') and decorator.attr == 'skip') for decorator in decorators)

--- a/nimoy/ast_tools/specs.py
+++ b/nimoy/ast_tools/specs.py
@@ -1,12 +1,13 @@
 import ast
-import _ast
+
 from nimoy.ast_tools.ast_metadata import SpecMetadata
 from nimoy.ast_tools.features import FeatureRegistrationTransformer
 
 
 class SpecTransformer(ast.NodeTransformer):
-    def __init__(self, spec_metadata) -> None:
+    def __init__(self, spec_location, spec_metadata) -> None:
         super().__init__()
+        self.spec_location = spec_location
         self.spec_metadata = spec_metadata
 
     def visit_ClassDef(self, class_node):
@@ -14,22 +15,26 @@ class SpecTransformer(ast.NodeTransformer):
         class_is_spec = class_node.name.endswith('Spec')
 
         if class_is_spec:
-            metadata = SpecMetadata(class_node.name)
-            self._register_spec(metadata)
-            FeatureRegistrationTransformer(metadata).visit(class_node)
+            has_spec_name = hasattr(self.spec_location, 'spec_name')
+            if not has_spec_name or (has_spec_name and self.spec_location.spec_name == class_node.name):
 
-            for feature_name in metadata.where_functions:
-                feature = next(
-                    feature for feature in class_node.body if hasattr(feature, 'name') and feature_name == feature.name)
-                index_of_feature = class_node.body.index(feature)
+                metadata = SpecMetadata(class_node.name)
+                self._register_spec(metadata)
+                FeatureRegistrationTransformer(metadata).visit(class_node)
 
-                index_to_insert_where = index_of_feature + 1
-                where_function_to_insert = metadata.where_functions[feature_name]
+                for feature_name in metadata.where_functions:
+                    feature = next(
+                        feature for feature in class_node.body if
+                        hasattr(feature, 'name') and feature_name == feature.name)
+                    index_of_feature = class_node.body.index(feature)
 
-                if (index_to_insert_where + 1) > len(class_node.body):
-                    class_node.body.append(where_function_to_insert)
-                else:
-                    class_node.body.insert(index_to_insert_where, where_function_to_insert)
+                    index_to_insert_where = index_of_feature + 1
+                    where_function_to_insert = metadata.where_functions[feature_name]
+
+                    if (index_to_insert_where + 1) > len(class_node.body):
+                        class_node.body.append(where_function_to_insert)
+                    else:
+                        class_node.body.insert(index_to_insert_where, where_function_to_insert)
 
         return class_node
 

--- a/nimoy/ast_tools/specs.py
+++ b/nimoy/ast_tools/specs.py
@@ -20,7 +20,7 @@ class SpecTransformer(ast.NodeTransformer):
 
                 metadata = SpecMetadata(class_node.name)
                 self._register_spec(metadata)
-                FeatureRegistrationTransformer(metadata).visit(class_node)
+                FeatureRegistrationTransformer(self.spec_location, metadata).visit(class_node)
 
                 for feature_name in metadata.where_functions:
                     feature = next(

--- a/nimoy/runner/spec_finder.py
+++ b/nimoy/runner/spec_finder.py
@@ -20,8 +20,8 @@ class SpecFinder:
         for suggested_location in suggested_locations:
             normalized_suggested_location = self._normalize_suggested_location(suggested_location)
 
-            if normalized_suggested_location.endswith('spec.py'):
-                self.spec_locations.append(normalized_suggested_location)
+            if 'spec.py' in normalized_suggested_location:
+                self.spec_locations.append(Location(normalized_suggested_location))
             else:
                 self._find_specs_in_directory(normalized_suggested_location)
 
@@ -34,4 +34,37 @@ class SpecFinder:
     def _find_specs_in_directory(self, directory):
         for root, dir_names, file_names in os.walk(directory):
             for filename in fnmatch.filter(file_names, '*spec.py'):
-                self.spec_locations.append(os.path.join(root, filename))
+                self.spec_locations.append(Location(os.path.join(root, filename)))
+
+
+class Location:
+    def __init__(self, suggested_location):
+
+        # Format may be:
+        # - some_spec.py
+        # - some_spec.py::SpecName
+        # - some_spec.py::feature_name
+        # - some_spec.py::SpecName::feature_name
+        split_suggested_location = suggested_location.split("::")
+
+        # some_spec.py
+        if len(split_suggested_location) == 1:
+            self.spec_path = split_suggested_location[0]
+
+        # some_spec.py::SpecName or some_spec.py::feature_name
+        if len(split_suggested_location) == 2:
+            self.spec_path = split_suggested_location[0]
+
+            # some_spec.py::SpecName
+            if split_suggested_location[1][0].isupper():
+                self.spec_name = split_suggested_location[1]
+
+            # some_spec.py::feature_name
+            else:
+                self.feature_name = split_suggested_location[1]
+
+        # some_spec.py::SpecName::feature_name
+        if len(split_suggested_location) == 3:
+            self.spec_path = split_suggested_location[0]
+            self.spec_name = split_suggested_location[1]
+            self.feature_name = split_suggested_location[2]

--- a/nimoy/runner/spec_loader.py
+++ b/nimoy/runner/spec_loader.py
@@ -6,14 +6,14 @@ class SpecLoader:
         super().__init__()
         self.ast_chain = ast_chain
 
-    def load(self, spec_contents):
+    def load(self, spec_locations_and_contents):
         def specs():
-            for spec_file_location, text in spec_contents:
+            for spec_location, text in spec_locations_and_contents:
                 node = ast.parse(text, mode='exec')
 
                 metadata_of_specs_from_node = self.ast_chain.apply(node)
                 ast.fix_missing_locations(node)
-                compiled = compile(node, spec_file_location, 'exec')
+                compiled = compile(node, spec_location.spec_path, 'exec')
 
                 spec_namespace = {}
                 exec(compiled, spec_namespace)

--- a/nimoy/runner/spec_loader.py
+++ b/nimoy/runner/spec_loader.py
@@ -11,7 +11,7 @@ class SpecLoader:
             for spec_location, text in spec_locations_and_contents:
                 node = ast.parse(text, mode='exec')
 
-                metadata_of_specs_from_node = self.ast_chain.apply(node)
+                metadata_of_specs_from_node = self.ast_chain.apply(spec_location, node)
                 ast.fix_missing_locations(node)
                 compiled = compile(node, spec_location.spec_path, 'exec')
 

--- a/nimoy/runner/spec_reader.py
+++ b/nimoy/runner/spec_reader.py
@@ -6,7 +6,7 @@ class SpecReader:
     def read(self, spec_locations):
         def spec_contents():
             for spec_file_location in spec_locations:
-                text = self.resource_reader.read(spec_file_location)
+                text = self.resource_reader.read(spec_file_location.spec_path)
                 yield (spec_file_location, text)
 
         return spec_contents()

--- a/nimoy/spec_runner.py
+++ b/nimoy/spec_runner.py
@@ -12,12 +12,12 @@ from nimoy.runner.spec_reader import SpecReader
 class SpecRunner:
     def run(self, execution_framework):
         spec_locations = SpecRunner._find_specs()
-        spec_contents = SpecRunner._read_specs(spec_locations)
-        return SpecRunner._run_on_contents(execution_framework, spec_contents)
+        spec_locations_and_contents = SpecRunner._read_specs(spec_locations)
+        return SpecRunner._run_on_contents(execution_framework, spec_locations_and_contents)
 
     @staticmethod
-    def _run_on_contents(execution_framework, spec_contents):
-        specs = SpecRunner._load_specs(spec_contents)
+    def _run_on_contents(execution_framework, spec_locations_and_contents):
+        specs = SpecRunner._load_specs(spec_locations_and_contents)
         return SpecRunner._execute_specs(execution_framework, specs)
 
     @staticmethod
@@ -34,8 +34,8 @@ class SpecRunner:
         return SpecReader(fs_resource_reader).read(spec_locations)
 
     @staticmethod
-    def _load_specs(spec_contents):
-        return SpecLoader(ast_chain).load(spec_contents)
+    def _load_specs(spec_locations_and_contents):
+        return SpecLoader(ast_chain).load(spec_locations_and_contents)
 
     @staticmethod
     def _execute_specs(execution_framework, specs):

--- a/nimoy/spec_runner.py
+++ b/nimoy/spec_runner.py
@@ -24,7 +24,9 @@ class SpecRunner:
     def _find_specs():
         parser = argparse.ArgumentParser(prog='nimoy', description='Run a suite of Nimoy specs.')
         parser.add_argument('specs', metavar='S', type=str, nargs='*',
-                            help='A path to a spec file to execute or a directory to scan for spec files')
+                            help="""A path to a spec file to execute or a directory to scan for spec files.
+                            When naming a file it is possible to select which spec or feature to run. some_spec.py[::SpecName[::feature_name]]
+                            """)
         args = parser.parse_args()
         suggested_locations = args.specs
         return SpecFinder(os.getcwd()).find(suggested_locations)

--- a/specs/nimoy/ast_tools/ast_chain_spec.py
+++ b/specs/nimoy/ast_tools/ast_chain_spec.py
@@ -1,6 +1,8 @@
 from unittest import mock
-from nimoy.specification import Specification
+
 from nimoy.ast_tools import ast_chain
+from nimoy.runner.spec_finder import Location
+from nimoy.specification import Specification
 
 
 class AstChainSpec(Specification):
@@ -10,7 +12,7 @@ class AstChainSpec(Specification):
         with given:
             node = {}
         with when:
-            spec_metadata = ast_chain.apply(node)
+            spec_metadata = ast_chain.apply(Location('some_spec.py'), node)
         with then:
             isinstance(spec_metadata, list) == True
             1 * spec_transformer_mock.return_value.visit(node)

--- a/specs/nimoy/ast_tools/features_spec.py
+++ b/specs/nimoy/ast_tools/features_spec.py
@@ -1,8 +1,10 @@
-from unittest import mock
 import ast
-from nimoy.specification import Specification
-from nimoy.ast_tools.features import FeatureRegistrationTransformer
+from unittest import mock
+
 from nimoy.ast_tools.ast_metadata import SpecMetadata
+from nimoy.ast_tools.features import FeatureRegistrationTransformer
+from nimoy.runner.spec_finder import Location
+from nimoy.specification import Specification
 
 
 class FeatureRegistrationTransformerSpec(Specification):
@@ -11,13 +13,19 @@ class FeatureRegistrationTransformerSpec(Specification):
     @mock.patch('nimoy.ast_tools.features.FeatureBlockTransformer')
     def a_feature_was_added(self, feature_block_transformer, feature_block_rule_enforcer):
         with setup:
-            module_definition = \
-                'class JSpec:\n    def test_jim(self):\n        pass\n    def _jim(self):\n        pass\n\n'
+            module_definition = """
+class JSpec:
+    def test_jim(self):
+        pass
+    def _jim(self):
+        pass
+        
+            """
             node = ast.parse(module_definition, mode='exec')
             metadata = SpecMetadata('jim')
 
         with when:
-            FeatureRegistrationTransformer(metadata).visit(node)
+            FeatureRegistrationTransformer(Location('some_spec.py'), metadata).visit(node)
 
         with then:
             len(metadata.features) == 1
@@ -31,9 +39,44 @@ class FeatureRegistrationTransformerSpec(Specification):
 
     @mock.patch('nimoy.ast_tools.features.FeatureBlockRuleEnforcer')
     @mock.patch('nimoy.ast_tools.features.FeatureBlockTransformer')
+    def only_the_specified_feature_was_added(self, feature_block_transformer, feature_block_rule_enforcer):
+        with setup:
+            module_definition = """
+class JSpec:
+    def test_jim(self):
+        pass
+    def test_bob(self):
+        pass
+    def _jim(self):
+        pass
+        
+            """
+            node = ast.parse(module_definition, mode='exec')
+            metadata = SpecMetadata('jim')
+
+        with when:
+            FeatureRegistrationTransformer(Location('some_spec.py::test_bob'), metadata).visit(node)
+
+        with then:
+            len(metadata.features) == 1
+            metadata.features[0] == 'test_bob'
+
+            feature_block_transformer.assert_called_once_with(metadata, 'test_bob')
+            1 * feature_block_transformer.return_value.visit(node.body[0].body[1])
+
+            feature_block_rule_enforcer.assert_called_once_with(metadata, 'test_bob', node.body[0].body[1])
+            1 * feature_block_rule_enforcer.return_value.enforce_tail_end_rules()
+
+    @mock.patch('nimoy.ast_tools.features.FeatureBlockRuleEnforcer')
+    @mock.patch('nimoy.ast_tools.features.FeatureBlockTransformer')
     def a_feature_with_where_block_was_added(self, feature_block_transformer, feature_block_rule_enforcer):
         with setup:
-            module_definition = 'class JSpec:\n    def test_jim(self):\n        pass\n\n'
+            module_definition = """
+class JSpec:
+    def test_jim(self):
+        pass
+            
+            """
             node = ast.parse(module_definition, mode='exec')
             metadata = SpecMetadata('jim')
 
@@ -47,7 +90,7 @@ class FeatureRegistrationTransformerSpec(Specification):
             feature_block_transformer.return_value.visit.side_effect = visit
 
         with when:
-            FeatureRegistrationTransformer(metadata).visit(node)
+            FeatureRegistrationTransformer(Location('some_spec.py'), metadata).visit(node)
 
         with then:
             len(metadata.features) == 1

--- a/specs/nimoy/integration/specs_integration_spec.py
+++ b/specs/nimoy/integration/specs_integration_spec.py
@@ -1,5 +1,7 @@
 import ast
+
 from nimoy.ast_tools.specs import SpecTransformer
+from nimoy.runner.spec_finder import Location
 from nimoy.specification import Specification
 
 
@@ -25,7 +27,7 @@ class JimbobSpec(Specification):
 
         with when:
             found_metadata = []
-            SpecTransformer(found_metadata).visit(node)
+            SpecTransformer(Location('some_spec.py'), found_metadata).visit(node)
         with then:
             len(node.body[1].body) == 2  # The where method should have been extracted to class level
             node.body[1].body[1].name == 'my_feature_where'

--- a/specs/nimoy/runner/specification_finder_spec.py
+++ b/specs/nimoy/runner/specification_finder_spec.py
@@ -1,8 +1,9 @@
 import os
 import tempfile
 
-from nimoy.specification import Specification
+from nimoy.runner.spec_finder import Location
 from nimoy.runner.spec_finder import SpecFinder
+from nimoy.specification import Specification
 
 temp_spec = tempfile.NamedTemporaryFile(suffix='_spec.py')
 
@@ -15,25 +16,73 @@ class SpecificationFinderSpec(Specification):
 
         with then:
             len(spec_locations) == 1
-            spec_locations[0] @ temp_spec.name
+            spec_locations[0].spec_path @ temp_spec.name
 
     def explicit_spec_path(self):
         with when:
             spec_locations = SpecFinder('/some/working/dir').find([temp_spec.name])
         with then:
             len(spec_locations) == 1
-            spec_locations[0] @ temp_spec.name
+            spec_locations[0].spec_path @ temp_spec.name
 
     def explicit_spec_directory(self):
         with when:
             spec_locations = SpecFinder('/some/working/dir').find([os.path.dirname(temp_spec.name)])
         with then:
             len(spec_locations) == 1
-            spec_locations[0] @ temp_spec.name
+            spec_locations[0].spec_path @ temp_spec.name
 
     def relative_spec_path(self):
         with when:
             spec_locations = SpecFinder('/some/working/dir').find(['jim_spec.py'])
         with then:
             len(spec_locations) == 1
-            spec_locations[0] @ '/some/working/dir/jim_spec.py'
+            spec_locations[0].spec_path @ '/some/working/dir/jim_spec.py'
+
+    def full_path(self):
+        with when:
+            spec_locations = SpecFinder('/some/working/dir').find(['jim_spec.py::SpecName::feature_name'])
+        with then:
+            len(spec_locations) == 1
+            spec_locations[0].spec_path @ '/some/working/dir/jim_spec.py'
+            spec_locations[0].spec_name == 'SpecName'
+            spec_locations[0].feature_name == 'feature_name'
+
+
+class SpecificationLocationSpec(Specification):
+
+    def spec_path(self):
+        with when:
+            location = Location('some_spec.py')
+
+        with then:
+            location.spec_path == 'some_spec.py'
+            hasattr(location, 'spec_name') == False
+            hasattr(location, 'feature_name') == False
+
+    def spec_path_and_name(self):
+        with when:
+            location = Location('some_spec.py::SpecName')
+
+        with then:
+            location.spec_path == 'some_spec.py'
+            location.spec_name == 'SpecName'
+            hasattr(location, 'feature_name') == False
+
+    def spec_path_and_feature_name(self):
+        with when:
+            location = Location('some_spec.py::feature_name')
+
+        with then:
+            location.spec_path == 'some_spec.py'
+            hasattr(location, 'spec_name') == False
+            location.feature_name == 'feature_name'
+
+    def spec_path_and_spec_name_and_feature_name(self):
+        with when:
+            location = Location('some_spec.py::SpecName::feature_name')
+
+        with then:
+            location.spec_path == 'some_spec.py'
+            location.spec_name == 'SpecName'
+            location.feature_name == 'feature_name'

--- a/specs/nimoy/runner/specification_loader_spec.py
+++ b/specs/nimoy/runner/specification_loader_spec.py
@@ -1,7 +1,9 @@
 from unittest import mock
-from nimoy.specification import Specification
-from nimoy.runner.spec_loader import SpecLoader
+
 from nimoy.ast_tools.ast_metadata import SpecMetadata
+from nimoy.runner.spec_finder import Location
+from nimoy.runner.spec_loader import SpecLoader
+from nimoy.specification import Specification
 
 
 class SpecificationLoaderSpec(Specification):
@@ -13,7 +15,8 @@ class SpecificationLoaderSpec(Specification):
             ast_chain.apply.return_value = [metadata]
 
         with when:
-            returned_spec_metadata = SpecLoader(ast_chain).load([('/path/to/spec.py', 'class Jimbob:\n    pass')])
+            returned_spec_metadata = SpecLoader(ast_chain).load(
+                [(Location('/path/to/spec.py'), 'class Jimbob:\n    pass')])
 
         with then:
             spec_metadata = next(returned_spec_metadata)

--- a/specs/nimoy/runner/specification_reader_spec.py
+++ b/specs/nimoy/runner/specification_reader_spec.py
@@ -1,17 +1,22 @@
 from unittest import mock
-from nimoy.specification import Specification
+
+from nimoy.runner.spec_finder import Location
 from nimoy.runner.spec_reader import SpecReader
+from nimoy.specification import Specification
 
 
 class SpecificationReaderSpec(Specification):
     def read(self):
         with given:
+            location = Location('/path/to/spec.py')
             reader_mock = mock.Mock()
             reader_mock.read.return_value = 'class Jimbob:\n    pass'
 
         with when:
-            spec_contents = SpecReader(reader_mock).read(['/path/to/spec.py'])
+            spec_contents = SpecReader(reader_mock).read([location])
 
         with then:
-            next(spec_contents) == ('/path/to/spec.py', 'class Jimbob:\n    pass')
+            (location, contents) = next(spec_contents)
+            location.spec_path == '/path/to/spec.py'
+            contents == 'class Jimbob:\n    pass'
             reader_mock.read.assert_called_once()

--- a/specs/nimoy/runner_helper.py
+++ b/specs/nimoy/runner_helper.py
@@ -1,5 +1,6 @@
 from io import StringIO
 
+from nimoy.runner.spec_finder import Location
 from nimoy.runner.unittest_execution_framework import UnitTestExecutionFramework
 from nimoy.spec_runner import SpecRunner
 
@@ -7,4 +8,4 @@ from nimoy.spec_runner import SpecRunner
 def run_spec_contents(spec_contents):
     str_io = StringIO()
     execution_framework = UnitTestExecutionFramework(stream=str_io)
-    return SpecRunner._run_on_contents(execution_framework, [('/fake/path.py', spec_contents)])
+    return SpecRunner._run_on_contents(execution_framework, [(Location('/fake/path.py'), spec_contents)])


### PR DESCRIPTION
Expanded the syntax of the `specs`/`S` command line parameter to support selecting specs and features to run:
Format may be:

- `some_spec.py`
- `some_spec.py::SpecName`
- `some_spec.py::feature_name`
- `some_spec.py::SpecName::feature_name`