### PR TITLE
Adding Power Assertion Rendering

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ twine = "*"
 mkdocs = "*"
 pylint = "*"
 mkdocs-material = "*"
+astor = "*"
 
 [packages]
 pyhamcrest = "==2.0.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "efc8507c9802ded915284558dbfe698736c709d083839d08382659930b635c72"
+            "sha256": "fd662a76b0f7b857af48a67e9410f816fddd977ac98f3be8ed155f15e77d1ad7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "astor": {
+            "hashes": [
+                "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5",
+                "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"
+            ],
+            "index": "pypi",
+            "version": "==0.8.1"
+        },
         "pyhamcrest": {
             "hashes": [
                 "sha256:412e00137858f04bde0729913874a48485665f2d36fe9ee449f26be864af9316",
@@ -34,13 +42,21 @@
         }
     },
     "develop": {
+        "astor": {
+            "hashes": [
+                "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5",
+                "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"
+            ],
+            "index": "pypi",
+            "version": "==0.8.1"
+        },
         "astroid": {
             "hashes": [
-                "sha256:6b0ed1af831570e500e2437625979eaa3b36011f66ddfc4ce930128610258ca9",
-                "sha256:cd80bf957c49765dce6d92c43163ff9d2abc43132ce64d4b1b47717c6d2522df"
+                "sha256:4db03ab5fc3340cf619dbc25e42c2cc3755154ce6009469766d7143d1fc2ee4e",
+                "sha256:8a398dfce302c13f14bab13e2b14fe385d32b73f4e4853b9bdfb64598baa1975"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.5.2"
+            "markers": "python_version ~= '3.6'",
+            "version": "==2.5.6"
         },
         "bleach": {
             "hashes": [
@@ -52,10 +68,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
-                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
             ],
-            "version": "==2020.12.5"
+            "version": "==2021.5.30"
         },
         "chardet": {
             "hashes": [
@@ -67,11 +83,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==7.1.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.1"
         },
         "colorama": {
             "hashes": [
@@ -83,18 +99,17 @@
         },
         "docutils": {
             "hashes": [
-                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
-                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
+                "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125",
+                "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.16"
+            "version": "==0.17.1"
         },
-        "future": {
+        "ghp-import": {
             "hashes": [
-                "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
+                "sha256:753de2eace6e0f7d4edfb3cce5e3c3b98cd52aadb80163303d1d036bda7b4483"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==0.18.2"
+            "version": "==2.0.1"
         },
         "idna": {
             "hashes": [
@@ -106,35 +121,27 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:036eae7ebbd41db176774c42e80f3288a1e41c7ebfc8ed099a94653973ebd00f",
-                "sha256:6fd684b4c6c7bb36d57e93d57fc244b5ffc08faa1c298bcda3dfbbbf19d7550a"
+                "sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00",
+                "sha256:b142cc1dd1342f31ff04bb7d022492b09920cb64fed867cd3ea6f80fe3ebd139"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.9.0"
+            "version": "==4.5.0"
         },
         "isort": {
             "hashes": [
                 "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6",
                 "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==5.8.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
-                "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.11.3"
-        },
-        "joblib": {
-            "hashes": [
-                "sha256:9c17567692206d2f3fb9ecf5e991084254fe631665c450b443761c4186a613f7",
-                "sha256:feeb1ec69c4d45129954f1b7034954241eedfd6ba39b5e9e4b6883be3332d5e5"
+                "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4",
+                "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.0.1"
+            "version": "==3.0.1"
         },
         "keyring": {
             "hashes": [
@@ -172,22 +179,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.6.0"
         },
-        "livereload": {
-            "hashes": [
-                "sha256:776f2f865e59fde56490a56bcc6773b6917366bce0c267c60ee8aaf1a0959869"
-            ],
-            "version": "==2.6.3"
-        },
-        "lunr": {
-            "extras": [
-                "languages"
-            ],
-            "hashes": [
-                "sha256:aab3f489c4d4fab4c1294a257a30fec397db56f0a50273218ccc3efdbf01d6ca",
-                "sha256:c4fb063b98eff775dd638b3df380008ae85e6cb1d1a24d1cd81a10ef6391c26e"
-            ],
-            "version": "==0.5.8"
-        },
         "markdown": {
             "hashes": [
                 "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49",
@@ -198,61 +189,43 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
-                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
-                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
-                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
-                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
-                "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f",
-                "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39",
-                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
-                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
-                "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014",
-                "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f",
-                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
-                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
-                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
-                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
-                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
-                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
-                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
-                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
-                "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
-                "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1",
-                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
-                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
-                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
-                "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850",
-                "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0",
-                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
-                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
-                "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb",
-                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
-                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
-                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
-                "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1",
-                "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2",
-                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
-                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
-                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
-                "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7",
-                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
-                "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8",
-                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
-                "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193",
-                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
-                "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b",
-                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
-                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
-                "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5",
-                "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c",
-                "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032",
-                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
-                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be",
-                "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.1.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
         },
         "mccabe": {
             "hashes": [
@@ -261,21 +234,29 @@
             ],
             "version": "==0.6.1"
         },
+        "mergedeep": {
+            "hashes": [
+                "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8",
+                "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.3.4"
+        },
         "mkdocs": {
             "hashes": [
-                "sha256:096f52ff52c02c7e90332d2e53da862fde5c062086e1b5356a6e392d5d60f5e9",
-                "sha256:f0b61e5402b99d7789efa032c7a74c90a20220a9c81749da06dbfbcbd52ffb39"
+                "sha256:11141126e5896dd9d279b3e4814eb488e409a0990fb638856255020406a8e2e7",
+                "sha256:6e0ea175366e3a50d334597b0bc042b8cebd512398cdd3f6f34842d0ef524905"
             ],
             "index": "pypi",
-            "version": "==1.1.2"
+            "version": "==1.2.1"
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:187f59e0fbf1600c68f1b5d455d8a848ff5bca0bab9fff09ae79bb0d606c7271",
-                "sha256:f8180f0b3c1e0fbe2f6337a6b1131c42cc07941cf151263ffe4ccf742aba0aed"
+                "sha256:08eaf9f77c6d026706397bae2c50d202cfe3a81ef984027b671b4acd365dfc5b",
+                "sha256:e555c66ece5eab7023c4733270dc7627280e707e5082dab278d6a7a4881d2435"
             ],
             "index": "pypi",
-            "version": "==7.0.7"
+            "version": "==7.1.8"
         },
         "mkdocs-material-extensions": {
             "hashes": [
@@ -284,12 +265,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
-        },
-        "nltk": {
-            "hashes": [
-                "sha256:845365449cd8c5f9731f7cb9f8bd6fd0767553b9d53af9eb1b3abf7700936b35"
-            ],
-            "version": "==3.5"
         },
         "packaging": {
             "hashes": [
@@ -308,35 +283,43 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94",
-                "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"
+                "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f",
+                "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==2.8.1"
+            "version": "==2.9.0"
         },
         "pylint": {
             "hashes": [
-                "sha256:0e21d3b80b96740909d77206d741aa3ce0b06b41be375d92e1f3244a274c1f8a",
-                "sha256:d09b0b07ba06bcdff463958f53f23df25e740ecd81895f7d2699ec04bbd8dc3b"
+                "sha256:0a049c5d47b629d9070c3932d13bff482b12119b6a241a93bc460b0be16953c8",
+                "sha256:792b38ff30903884e4a9eab814ee3523731abd3c463f3ba48d7b627e87013484"
             ],
             "index": "pypi",
-            "version": "==2.7.2"
+            "version": "==2.8.3"
         },
         "pymdown-extensions": {
             "hashes": [
-                "sha256:478b2c04513fbb2db61688d5f6e9030a92fb9be14f1f383535c43f7be9dff95b",
-                "sha256:632371fa3bf1b21a0e3f4063010da59b41db049f261f4c0b0872069a9b6d1735"
+                "sha256:141452d8ed61165518f2c923454bf054866b85cf466feedb0eb68f04acdc2560",
+                "sha256:b6daa94aad9e1310f9c64c8b1f01e4ce82937ab7eb53bfc92876a97aca02a6f4"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.1.1"
+            "version": "==8.2"
         },
         "pyparsing": {
             "hashes": [
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.1"
         },
         "pyyaml": {
             "hashes": [
@@ -373,58 +356,20 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==5.4.1"
         },
+        "pyyaml-env-tag": {
+            "hashes": [
+                "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb",
+                "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.1"
+        },
         "readme-renderer": {
             "hashes": [
                 "sha256:63b4075c6698fcfa78e584930f07f39e05d46f3ec97f65006e430b595ca6348c",
                 "sha256:92fd5ac2bf8677f310f3303aa4bce5b9d5f9f2094ab98c29f13791d7b805a3db"
             ],
             "version": "==29.0"
-        },
-        "regex": {
-            "hashes": [
-                "sha256:07ef35301b4484bce843831e7039a84e19d8d33b3f8b2f9aab86c376813d0139",
-                "sha256:13f50969028e81765ed2a1c5fcfdc246c245cf8d47986d5172e82ab1a0c42ee5",
-                "sha256:14de88eda0976020528efc92d0a1f8830e2fb0de2ae6005a6fc4e062553031fa",
-                "sha256:159fac1a4731409c830d32913f13f68346d6b8e39650ed5d704a9ce2f9ef9cb3",
-                "sha256:18e25e0afe1cf0f62781a150c1454b2113785401ba285c745acf10c8ca8917df",
-                "sha256:201e2619a77b21a7780580ab7b5ce43835e242d3e20fef50f66a8df0542e437f",
-                "sha256:360a01b5fa2ad35b3113ae0c07fb544ad180603fa3b1f074f52d98c1096fa15e",
-                "sha256:39c44532d0e4f1639a89e52355b949573e1e2c5116106a395642cbbae0ff9bcd",
-                "sha256:3d9356add82cff75413bec360c1eca3e58db4a9f5dafa1f19650958a81e3249d",
-                "sha256:3d9a7e215e02bd7646a91fb8bcba30bc55fd42a719d6b35cf80e5bae31d9134e",
-                "sha256:4651f839dbde0816798e698626af6a2469eee6d9964824bb5386091255a1694f",
-                "sha256:486a5f8e11e1f5bbfcad87f7c7745eb14796642323e7e1829a331f87a713daaa",
-                "sha256:4b8a1fb724904139149a43e172850f35aa6ea97fb0545244dc0b805e0154ed68",
-                "sha256:4c0788010a93ace8a174d73e7c6c9d3e6e3b7ad99a453c8ee8c975ddd9965643",
-                "sha256:4c2e364491406b7888c2ad4428245fc56c327e34a5dfe58fd40df272b3c3dab3",
-                "sha256:575a832e09d237ae5fedb825a7a5bc6a116090dd57d6417d4f3b75121c73e3be",
-                "sha256:5770a51180d85ea468234bc7987f5597803a4c3d7463e7323322fe4a1b181578",
-                "sha256:633497504e2a485a70a3268d4fc403fe3063a50a50eed1039083e9471ad0101c",
-                "sha256:63f3ca8451e5ff7133ffbec9eda641aeab2001be1a01878990f6c87e3c44b9d5",
-                "sha256:709f65bb2fa9825f09892617d01246002097f8f9b6dde8d1bb4083cf554701ba",
-                "sha256:808404898e9a765e4058bf3d7607d0629000e0a14a6782ccbb089296b76fa8fe",
-                "sha256:882f53afe31ef0425b405a3f601c0009b44206ea7f55ee1c606aad3cc213a52c",
-                "sha256:8bd4f91f3fb1c9b1380d6894bd5b4a519409135bec14c0c80151e58394a4e88a",
-                "sha256:8e65e3e4c6feadf6770e2ad89ad3deb524bcb03d8dc679f381d0568c024e0deb",
-                "sha256:976a54d44fd043d958a69b18705a910a8376196c6b6ee5f2596ffc11bff4420d",
-                "sha256:a0d04128e005142260de3733591ddf476e4902c0c23c1af237d9acf3c96e1b38",
-                "sha256:a0df9a0ad2aad49ea3c7f65edd2ffb3d5c59589b85992a6006354f6fb109bb18",
-                "sha256:a2ee026f4156789df8644d23ef423e6194fad0bc53575534101bb1de5d67e8ce",
-                "sha256:a59a2ee329b3de764b21495d78c92ab00b4ea79acef0f7ae8c1067f773570afa",
-                "sha256:b97ec5d299c10d96617cc851b2e0f81ba5d9d6248413cd374ef7f3a8871ee4a6",
-                "sha256:b98bc9db003f1079caf07b610377ed1ac2e2c11acc2bea4892e28cc5b509d8d5",
-                "sha256:b9d8d286c53fe0cbc6d20bf3d583cabcd1499d89034524e3b94c93a5ab85ca90",
-                "sha256:bcd945175c29a672f13fce13a11893556cd440e37c1b643d6eeab1988c8b209c",
-                "sha256:c66221e947d7207457f8b6f42b12f613b09efa9669f65a587a2a71f6a0e4d106",
-                "sha256:c782da0e45aff131f0bed6e66fbcfa589ff2862fc719b83a88640daa01a5aff7",
-                "sha256:cb4ee827857a5ad9b8ae34d3c8cc51151cb4a3fe082c12ec20ec73e63cc7c6f0",
-                "sha256:d47d359545b0ccad29d572ecd52c9da945de7cd6cf9c0cfcb0269f76d3555689",
-                "sha256:dc9963aacb7da5177e40874585d7407c0f93fb9d7518ec58b86e562f633f36cd",
-                "sha256:ea2f41445852c660ba7c3ebf7d70b3779b20d9ca8ba54485a17740db49f46932",
-                "sha256:f5d0c921c99297354cecc5a416ee4280bd3f20fd81b9fb671ca6be71499c3fdf",
-                "sha256:f85d6f41e34f6a2d1607e312820971872944f1661a73d33e1e82d35ea3305e14"
-            ],
-            "version": "==2021.3.17"
         },
         "requests": {
             "hashes": [
@@ -443,81 +388,34 @@
         },
         "rfc3986": {
             "hashes": [
-                "sha256:112398da31a3344dc25dbf477d8df6cb34f9278a94fee2625d89e4514be8bb9d",
-                "sha256:af9147e9aceda37c91a05f4deb128d4b4b49d6b199775fd2d2927768abdc8f50"
+                "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835",
+                "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"
             ],
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "six": {
             "hashes": [
-                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
-                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==1.15.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
         },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
-        },
-        "tornado": {
-            "hashes": [
-                "sha256:0a00ff4561e2929a2c37ce706cb8233b7907e0cdc22eab98888aca5dd3775feb",
-                "sha256:0d321a39c36e5f2c4ff12b4ed58d41390460f798422c4504e09eb5678e09998c",
-                "sha256:1e8225a1070cd8eec59a996c43229fe8f95689cb16e552d130b9793cb570a288",
-                "sha256:20241b3cb4f425e971cb0a8e4ffc9b0a861530ae3c52f2b0434e6c1b57e9fd95",
-                "sha256:25ad220258349a12ae87ede08a7b04aca51237721f63b1808d39bdb4b2164558",
-                "sha256:33892118b165401f291070100d6d09359ca74addda679b60390b09f8ef325ffe",
-                "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791",
-                "sha256:3447475585bae2e77ecb832fc0300c3695516a47d46cefa0528181a34c5b9d3d",
-                "sha256:34ca2dac9e4d7afb0bed4677512e36a52f09caa6fded70b4e3e1c89dbd92c326",
-                "sha256:3e63498f680547ed24d2c71e6497f24bca791aca2fe116dbc2bd0ac7f191691b",
-                "sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4",
-                "sha256:6196a5c39286cc37c024cd78834fb9345e464525d8991c21e908cc046d1cc02c",
-                "sha256:61b32d06ae8a036a6607805e6720ef00a3c98207038444ba7fd3d169cd998910",
-                "sha256:6286efab1ed6e74b7028327365cf7346b1d777d63ab30e21a0f4d5b275fc17d5",
-                "sha256:65d98939f1a2e74b58839f8c4dab3b6b3c1ce84972ae712be02845e65391ac7c",
-                "sha256:66324e4e1beede9ac79e60f88de548da58b1f8ab4b2f1354d8375774f997e6c0",
-                "sha256:6c77c9937962577a6a76917845d06af6ab9197702a42e1346d8ae2e76b5e3675",
-                "sha256:70dec29e8ac485dbf57481baee40781c63e381bebea080991893cd297742b8fd",
-                "sha256:7250a3fa399f08ec9cb3f7b1b987955d17e044f1ade821b32e5f435130250d7f",
-                "sha256:748290bf9112b581c525e6e6d3820621ff020ed95af6f17fedef416b27ed564c",
-                "sha256:7da13da6f985aab7f6f28debab00c67ff9cbacd588e8477034c0652ac141feea",
-                "sha256:8f959b26f2634a091bb42241c3ed8d3cedb506e7c27b8dd5c7b9f745318ddbb6",
-                "sha256:9de9e5188a782be6b1ce866e8a51bc76a0fbaa0e16613823fc38e4fc2556ad05",
-                "sha256:a48900ecea1cbb71b8c71c620dee15b62f85f7c14189bdeee54966fbd9a0c5bd",
-                "sha256:b87936fd2c317b6ee08a5741ea06b9d11a6074ef4cc42e031bc6403f82a32575",
-                "sha256:c77da1263aa361938476f04c4b6c8916001b90b2c2fdd92d8d535e1af48fba5a",
-                "sha256:cb5ec8eead331e3bb4ce8066cf06d2dfef1bfb1b2a73082dfe8a161301b76e37",
-                "sha256:cc0ee35043162abbf717b7df924597ade8e5395e7b66d18270116f8745ceb795",
-                "sha256:d14d30e7f46a0476efb0deb5b61343b1526f73ebb5ed84f23dc794bdb88f9d9f",
-                "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32",
-                "sha256:d3d20ea5782ba63ed13bc2b8c291a053c8d807a8fa927d941bd718468f7b950c",
-                "sha256:d3f7594930c423fd9f5d1a76bee85a2c36fd8b4b16921cae7e965f22575e9c01",
-                "sha256:dcef026f608f678c118779cd6591c8af6e9b4155c44e0d1bc0c87c036fb8c8c4",
-                "sha256:e0791ac58d91ac58f694d8d2957884df8e4e2f6687cdf367ef7eb7497f79eaa2",
-                "sha256:e385b637ac3acaae8022e7e47dfa7b83d3620e432e3ecb9a3f7f58f150e50921",
-                "sha256:e519d64089b0876c7b467274468709dadf11e41d65f63bba207e04217f47c085",
-                "sha256:e7229e60ac41a1202444497ddde70a48d33909e484f96eb0da9baf8dc68541df",
-                "sha256:ed3ad863b1b40cd1d4bd21e7498329ccaece75db5a5bf58cd3c9f130843e7102",
-                "sha256:f0ba29bafd8e7e22920567ce0d232c26d4d47c8b5cf4ed7b562b5db39fa199c5",
-                "sha256:fa2ba70284fa42c2a5ecb35e322e68823288a4251f9ba9cc77be04ae15eada68",
-                "sha256:fba85b6cd9c39be262fcd23865652920832b61583de2a2ca907dbd8e8a8c81e5"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==6.1"
         },
         "tqdm": {
             "hashes": [
-                "sha256:9fdf349068d047d4cfbe24862c425883af1db29bcddf4b0eeb2524f6fbdb23c7",
-                "sha256:d666ae29164da3e517fcf125e41d4fe96e5bb375cd87ff9763f6b38b5592fe33"
+                "sha256:24be966933e942be5f074c29755a95b315c69a91f839a29139bf26ffffe2d3fd",
+                "sha256:aa0c29f03f298951ac6318f7c8ce584e48fa22ec26396e6411e43d038243bdb2"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.59.0"
+            "version": "==4.61.1"
         },
         "twine": {
             "hashes": [
@@ -534,6 +432,29 @@
             ],
             "index": "pypi",
             "version": "==1.26.4"
+        },
+        "watchdog": {
+            "hashes": [
+                "sha256:0237db4d9024859bea27d0efb59fe75eef290833fd988b8ead7a879b0308c2db",
+                "sha256:104266a778906ae0e971368d368a65c4cd032a490a9fca5ba0b78c6c7ae11720",
+                "sha256:188145185c08c73c56f1478ccf1f0f0f85101191439679b35b6b100886ce0b39",
+                "sha256:1a62a4671796dc93d1a7262286217d9e75823c63d4c42782912d39a506d30046",
+                "sha256:255a32d44bbbe62e52874ff755e2eefe271b150e0ec240ad7718a62a7a7a73c4",
+                "sha256:3d6405681471ebe0beb3aa083998c4870e48b57f8afdb45ea1b5957cc5cf1014",
+                "sha256:4b219d46d89cfa49af1d73175487c14a318a74cb8c5442603fd13c6a5b418c86",
+                "sha256:581e3548159fe7d2a9f377a1fbcb41bdcee46849cca8ab803c7ac2e5e04ec77c",
+                "sha256:58ebb1095ee493008a7789d47dd62e4999505d82be89fc884d473086fccc6ebd",
+                "sha256:598d772beeaf9c98d0df946fbabf0c8365dd95ea46a250c224c725fe0c4730bc",
+                "sha256:668391e6c32742d76e5be5db6bf95c455fa4b3d11e76a77c13b39bccb3a47a72",
+                "sha256:6ef9fe57162c4c361692620e1d9167574ba1975ee468b24051ca11c9bba6438e",
+                "sha256:91387ee2421f30b75f7ff632c9d48f76648e56bf346a7c805c0a34187a93aab4",
+                "sha256:a42e6d652f820b2b94cd03156c62559a2ea68d476476dfcd77d931e7f1012d4a",
+                "sha256:a6471517315a8541a943c00b45f1d252e36898a3ae963d2d52509b89a50cb2b9",
+                "sha256:d34ce2261f118ecd57eedeef95fc2a495fc4a40b3ed7b3bf0bd7a8ccc1ab4f8f",
+                "sha256:edcd9ef3fd460bb8a98eb1fcf99941e9fd9f275f45f1a82cb1359ec92975d647"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.1.2"
         },
         "webencodings": {
             "hashes": [

--- a/nimoy/assertions/power.py
+++ b/nimoy/assertions/power.py
@@ -1,18 +1,149 @@
 from nimoy.compare.types import Types
 
 
-class ConstantValue:
-    def __init__(self, value):
-        self.value = value
-
-
-class Variable:
-    def __init__(self, name: str, value):
+class Expression:
+    def __init__(self, name: str, value, column: int, constant: bool = False, next_node=None):
         self.name = name
         self.value = value
+        self.column = column
+        self.constant = constant
+        self.next_node = next_node
+
+
+class Op:
+    def __init__(self, value: str, op: Types):
+        self.value = value
+        self.op = op
+
+
+class Assertion:
+    def __init__(self, left: Expression, right: Expression, op: Op):
+        self.left = left
+        self.right = right
+        self.op = op
 
 
 class PowerAssertions:
 
-    def assert_and_render(self, left, right, op: Types):
-        pass
+    def __init__(self):
+        # This var keeps track of value columns - columns where an expression begins and that expression has a value
+        # that needs to be rendered. This is so we know where to position all different the pipes (|) that lead from a
+        # value to its expression in the final render
+        self.columns = {}
+
+        # This var changes in place and represents a single value row in the final render. It keeps track of the values
+        # that need to be listed in the row of the current iterations. A row breaks whenever a value of an expression
+        # is longer than the expression itself. When a value is longer, it can break the column of the next expression
+        self.current_value_row = []
+
+        # Collection of all rendered value rows
+        self.value_rows = []
+
+        # We use this var to keep track of our position in the expression during the iteration
+        self.current_index = 0
+
+    def _append_and_reset_current_value_row(self):
+        joined_value_row = ''.join(self.current_value_row)
+
+        # Extra spaces may have been prematurely added for padding. Remove them only on the right because whitespace
+        # after the last listed value on that row is unnecessary
+        trimmed_value_row = joined_value_row.rstrip()
+        self.value_rows.append(trimmed_value_row)
+        self.current_value_row = []
+
+    def _append_assertion_node(self, assertion, side_expression):
+        # Starting with the left most node
+        current_node = assertion
+        while current_node is not None:
+
+            # First, add the name of the current node to the left side of the expression for the final render
+            side_expression.append(current_node.name)
+
+            # If we are starting with an empty value row, we need to start filling it
+            if len(self.current_value_row) == 0:
+
+                # Before we add the value of the current row, we need to check if there are any previous values that
+                # have been listed. Go through columns from 0 to the column of the current value, and fill in a pipe if
+                # there was a value at that column, or a space if there was no value at than column
+                for column in range(current_node.column):
+                    if column in self.columns and self.columns[column]:
+                        self.current_value_row.append('|')
+                    else:
+                        self.current_value_row.append(' ')
+
+            # Finally, if the current node isn't a constant, append the value of the current node to the current value
+            # row and list the column for later iterations. Constants should be added to the value rows as its redundant
+            if not current_node.constant:
+                self.current_value_row = self.current_value_row + list(str(current_node.value))
+                self.columns[current_node.column] = True
+
+            # If the value of the current node is longer than the expression itself, we need to start a new value row
+            # because this value may leak into the next value column
+            if len(str(current_node.value)) > len(current_node.name):
+
+                # Add the current value row to the list of finalized value rows and reset the current value row
+                self._append_and_reset_current_value_row()
+
+            # The value of the current node is equal or shorter than the name of the node
+            else:
+                # Pad the current value row with spaces for the remainder of the length of the current expression,
+                # ready for the next expression
+                length_of_range_to_pad = len(current_node.name) - len(str(current_node.value))
+                if length_of_range_to_pad == 0 and current_node.constant:
+                    length_of_range_to_pad = len(current_node.name)
+                for column in range(length_of_range_to_pad):
+                    self.current_value_row.append(' ')
+
+            # Bump the current index with the length of the current node name ready for the next iteration and move to
+            # the next node
+            self.current_index = (current_node.column + len(current_node.name)) - 1
+            current_node = current_node.next_node
+
+    def assert_and_render(self, assertion: Assertion):
+
+        # This var keeps all the expressions to the left of the comparator. We keep track of this so that we can later
+        # render the complete expression
+        left_expression = []
+
+        self._append_assertion_node(assertion.left, left_expression)
+
+        # We've completed the iteration over the left expression, now manually add the location of the comparator to the
+        # columns because we track the value of the comparator as well
+        self.current_index = self.current_index + 2
+        self.columns[self.current_index] = True
+
+        # Append the value of the comparator (True / False) to the current value row
+        self.current_value_row = self.current_value_row + list(str(f' {assertion.op.value}'))
+
+        # Add the current value row to the list of finalized value rows and reset the current value row
+        self._append_and_reset_current_value_row()
+
+        # Bump the current index in preparation for the iteration of the right expression
+        self.current_index = self.current_index + 2
+
+        right_expression = []
+        self._append_assertion_node(assertion.right, right_expression)
+
+        # Add the current value row to the list of finalized value rows and reset the current value row
+        self._append_and_reset_current_value_row()
+
+        # If the last expression on the right was a literal, a row of all pads and pipes will have already been added
+        # because the first thing we do when we handle a new expression node is to pad and pipe for all prior values.
+        # In the case of a literal the row will be padded and piped but no value will be added.
+        # In all other cases we need to create this first row with all pads and pipes
+        last_added_row = self.value_rows[-1]
+        if any(letter.isalnum() for letter in last_added_row):
+            for column in range(max(self.columns.keys()) + 1):
+                if column in self.columns and self.columns[column]:
+                    self.current_value_row.append('|')
+                else:
+                    self.current_value_row.append(' ')
+
+            # Add the current value row to the list of finalized value rows and reset the current value row
+            self._append_and_reset_current_value_row()
+
+        self.value_rows.reverse()
+
+        joined_values = "\n".join(self.value_rows) + '\n'
+        value = f"Assertion failed:\n{'.'.join(left_expression)} == {'.'.join(right_expression)}\n{joined_values}"
+        return value

--- a/nimoy/assertions/power.py
+++ b/nimoy/assertions/power.py
@@ -1,0 +1,18 @@
+from nimoy.compare.types import Types
+
+
+class ConstantValue:
+    def __init__(self, value):
+        self.value = value
+
+
+class Variable:
+    def __init__(self, name: str, value):
+        self.name = name
+        self.value = value
+
+
+class PowerAssertions:
+
+    def assert_and_render(self, left, right, op: Types):
+        pass

--- a/nimoy/ast_tools/ast_chain.py
+++ b/nimoy/ast_tools/ast_chain.py
@@ -1,8 +1,9 @@
 from nimoy.ast_tools.specs import SpecTransformer
+from nimoy.runner.metadata import RunnerContext
 
 
-def apply(spec_location, node):
+def apply(runner_context: RunnerContext, spec_location, node):
     spec_metadata = []
 
-    SpecTransformer(spec_location, spec_metadata).visit(node)
+    SpecTransformer(runner_context, spec_location, spec_metadata).visit(node)
     return spec_metadata

--- a/nimoy/ast_tools/expression_transformer.py
+++ b/nimoy/ast_tools/expression_transformer.py
@@ -1,5 +1,7 @@
 import _ast
 import ast
+from _ast import Dict, Constant
+from typing import Tuple
 
 from nimoy.ast_tools import ast_proxy
 from nimoy.compare.types import Types
@@ -52,6 +54,222 @@ class ComparisonExpressionTransformer(ast.NodeTransformer):
             args=[left_value, right_value, ast_proxy.ast_str(s=internal_comparison_type.name)],
             keywords=[]
         )
+        return expression_node
+
+
+# Converts assertion expressions to Nimoy power assertions.
+# This is done by taking the comparison expression and breaking it into a tree structure, made out of dictionaries,
+# where every element in the structure is one evaluable subexpression. The tree is then set as the argument to a
+# nimoy.specification.Specification._power_assert method call.
+# For example, an expression like:
+# jim == bob.mcbob
+# Will be transformed to an expression like:
+# self._power_assert( { 'name': 'jim', value: original-ast-node, 'next': {
+#     'name': '==', 'next': {
+#         'name': 'bob', value: original-ast-node, 'next': {
+#             'name': 'mcbob', value: original-ast-node
+#         }
+#     }
+# })
+#
+# The reason this transformed to vanilla dictionaries is that we need a way to pass this information to the
+# _power_assert without adding any classes that the user didn't import themselves
+class PowerAssertionTransformer(ast.NodeTransformer):
+
+    # Recursively transform the expression node AST to a linked dictionary structure AST. Supported nodes are Name,
+    # Constant and Attribute. Recursion occurs on every attribute node.
+    # The method always returns the root link
+    @staticmethod
+    def expression_node_ast_to_nimoy_expression_ast(ast_object) -> Tuple:
+        keys = []
+        values = []
+        if type(ast_object) is _ast.Name:
+            keys.append(Constant(value='type', kind=None))
+            values.append(Constant(value='exp', kind=None))
+
+            keys.append(Constant(value='name', kind=None))
+            values.append(Constant(value=ast_object.id, kind=None))
+
+            keys.append(Constant(value='value', kind=None))
+            values.append(ast_object)
+
+            keys.append(Constant(value='column', kind=None))
+            values.append(Constant(value=ast_object.col_offset, kind=None))
+
+            keys.append(Constant(value='end_column', kind=None))
+            # End col offset represents the next column after the node, assuming a zero based count. Nimoy considers
+            # The last character of the node name as the last column, so subtract by 1
+            values.append(Constant(value=ast_object.end_col_offset - 1, kind=None))
+
+            keys.append(Constant(value='constant', kind=None))
+            values.append(Constant(value=False, kind=None))
+        elif type(ast_object) is _ast.Constant:
+            keys.append(Constant(value='type', kind=None))
+            values.append(Constant(value='exp', kind=None))
+
+            keys.append(Constant(value='name', kind=None))
+            values.append(Constant(value=str(ast_object.value), kind=None))
+
+            keys.append(Constant(value='value', kind=None))
+            values.append(ast_object)
+
+            keys.append(Constant(value='column', kind=None))
+            values.append(Constant(value=ast_object.col_offset, kind=None))
+
+            keys.append(Constant(value='end_column', kind=None))
+            # End col offset represents the next column after the node, assuming a zero based count. Nimoy considers
+            # The last character of the node name as the last column, so subtract by 1
+            values.append(Constant(value=ast_object.end_col_offset - 1, kind=None))
+
+            keys.append(Constant(value='constant', kind=None))
+            values.append(Constant(value=True, kind=None))
+        elif type(ast_object) is _ast.Attribute:
+            next_dict = Dict(keys=[], values=[])
+
+            next_dict.keys.append(Constant(value='type', kind=None))
+            next_dict.values.append(Constant(value='exp', kind=None))
+
+            next_dict.keys.append(Constant(value='name', kind=None))
+            next_dict.values.append(Constant(value=ast_object.attr, kind=None))
+
+            next_dict.keys.append(Constant(value='value', kind=None))
+            next_dict.values.append(ast_object)
+
+            next_dict.keys.append(Constant(value='column', kind=None))
+            # Because attributes are separated by a period, the attributes start column can be calculated by adding 1
+            # to the end col offset of the attribute's parent
+            next_dict.values.append(Constant(value=ast_object.value.end_col_offset + 1, kind=None))
+
+            next_dict.keys.append(Constant(value='end_column', kind=None))
+            # End col offset represents the next column after the node, assuming a zero based count. Nimoy considers
+            # The last character of the node name as the last column, so subtract by 1
+            next_dict.values.append(Constant(value=ast_object.end_col_offset - 1, kind=None))
+
+            next_dict.keys.append(Constant(value='constant', kind=None))
+            next_dict.values.append(Constant(value=False, kind=None))
+
+            parent_keys, parent_values = PowerAssertionTransformer.expression_node_ast_to_nimoy_expression_ast(
+                ast_object.value)
+
+            parent_keys.append(Constant(value='next', kind=None))
+            parent_values.append(next_dict)
+
+            keys.extend(parent_keys)
+            values.extend(parent_values)
+
+        return keys, values
+
+    # Fetches the last link from the linked dictionaries
+    @staticmethod
+    def get_last_dictionary(d: Dict) -> Dict:
+        dict_to_return = None
+
+        rightmost_dict = d
+        while dict_to_return is None:
+
+            next_found_in_iteration = False
+            for i, key in enumerate(rightmost_dict.keys):
+                if type(key) != Constant:
+                    continue
+                if key.value == 'next':
+                    next_found_in_iteration = True
+                    rightmost_dict = rightmost_dict.values[i]
+                    break
+
+            if not next_found_in_iteration:
+                dict_to_return = rightmost_dict
+
+        return dict_to_return
+
+    # Transforms the operation AST node into an operation AST dictionary
+    @staticmethod
+    def op_ast_to_nimoy_op_ast(ast_object, ast_object_col_offset, complete_expression) -> Dict:
+        op_dict = Dict(keys=[], values=[])
+        op_dict.keys.append(Constant(value='type', kind=None))
+        op_dict.values.append(Constant(value='op', kind=None))
+
+        op_dict.keys.append(Constant(value='value', kind=None))
+        op_dict.values.append(complete_expression)
+
+        op_dict.keys.append(Constant(value='op', kind=None))
+        op = None
+        if type(ast_object) is _ast.Eq:
+            op = '=='
+        op_dict.values.append(Constant(value=op, kind=None))
+
+        op_dict.keys.append(Constant(value='column', kind=None))
+        op_dict.values.append(Constant(value=ast_object_col_offset, kind=None))
+
+        return op_dict
+
+    # Breaks the expression into a linked dictionary structure, where every evaluable node in the expression is a node
+    # in the structure
+    @staticmethod
+    def assert_ast_to_nimoy_expression_ast(node_value) -> Dict:
+        root_dict = Dict(keys=[], values=[])
+
+        # Transform the left side of the assertion into linked dictionaries
+        left = node_value.left
+        left_keys_to_append, left_values_to_append = PowerAssertionTransformer.expression_node_ast_to_nimoy_expression_ast(
+            left)
+
+        # Append the left nodes to the root
+        root_dict.keys.extend(left_keys_to_append)
+        root_dict.values.extend(left_values_to_append)
+
+        # Fetch the last dictionary. expression_node_ast_to_nimoy_expression_ast is a recursive operation and always
+        # returns the root node. We iterate until we find the last node to which we can then append the next node
+        last_dict = PowerAssertionTransformer.get_last_dictionary(root_dict)
+
+        # Transform the operation node to an op dictionary
+        op_dict = PowerAssertionTransformer.op_ast_to_nimoy_op_ast(node_value.ops[0], left.end_col_offset + 1,
+                                                                   node_value)
+
+        # Append the operation dictionary to the linked dictionaries
+        last_dict.keys.append(Constant(value='next', kind=None))
+        last_dict.values.append(op_dict)
+
+        # Transform the right side of the assertion into linked dictionaries
+        right_dict = Dict(keys=[], values=[])
+        right = node_value.comparators[0]
+        right_keys_to_append, right_values_to_append = PowerAssertionTransformer.expression_node_ast_to_nimoy_expression_ast(
+            right)
+        right_dict.keys.extend(right_keys_to_append)
+        right_dict.values.extend(right_values_to_append)
+
+        # Append the right nodes to the operation
+        op_dict.keys.append(Constant(value='next', kind=None))
+        op_dict.values.append(right_dict)
+
+        return root_dict
+
+    # Transforms the comparison expression to a power assert method call
+    def visit_Call(self, expression_node):
+        value = expression_node.value
+
+        # If the given node isn't a binary comparison operation, return it as is. We only translated expression like
+        # jim == bob
+        if not isinstance(value, _ast.Compare):
+            if isinstance(value, _ast.BinOp):
+                if hasattr(value, 'op') and not isinstance(value.op, _ast.MatMult):
+                    return expression_node
+            else:
+                return expression_node
+
+        # Break down the expression into a linked dictionaries made of vanilla dictionaries
+        power_assertion_dict = PowerAssertionTransformer.assert_ast_to_nimoy_expression_ast(value)
+
+        # Insert a power assert method call instead of the expression and set the linked dictionaries as an argument
+        expression_node.value = _ast.Call(
+            func=_ast.Attribute(
+                value=_ast.Name(id='self', ctx=_ast.Load()),
+                attr='_power_assert',
+                ctx=_ast.Load()
+            ),
+            args=[power_assertion_dict],
+            keywords=[]
+        )
+
         return expression_node
 
 

--- a/nimoy/ast_tools/features.py
+++ b/nimoy/ast_tools/features.py
@@ -2,13 +2,16 @@ import _ast
 import ast
 
 from nimoy.ast_tools import ast_proxy
+from nimoy.ast_tools.ast_metadata import SpecMetadata
 from nimoy.ast_tools.feature_blocks import FeatureBlockRuleEnforcer
 from nimoy.ast_tools.feature_blocks import FeatureBlockTransformer
+from nimoy.runner.metadata import RunnerContext
 
 
 class FeatureRegistrationTransformer(ast.NodeTransformer):
-    def __init__(self, spec_location, spec_metadata) -> None:
+    def __init__(self, runner_context: RunnerContext, spec_location, spec_metadata: SpecMetadata) -> None:
         super().__init__()
+        self.runner_context = runner_context
         self.spec_location = spec_location
         self.spec_metadata = spec_metadata
 
@@ -24,7 +27,7 @@ class FeatureRegistrationTransformer(ast.NodeTransformer):
             if not feature_name_specified or (
                     feature_name_specified and self.spec_location.feature_name == feature_name):
                 self.spec_metadata.add_feature(feature_name)
-                FeatureBlockTransformer(self.spec_metadata, feature_name).visit(feature_node)
+                FeatureBlockTransformer(self.runner_context, self.spec_metadata, feature_name).visit(feature_node)
                 FeatureBlockRuleEnforcer(self.spec_metadata, feature_name, feature_node).enforce_tail_end_rules()
 
         feature_variables = self.spec_metadata.feature_variables.get(feature_name)

--- a/nimoy/ast_tools/specs.py
+++ b/nimoy/ast_tools/specs.py
@@ -1,12 +1,15 @@
 import ast
+from typing import List
 
 from nimoy.ast_tools.ast_metadata import SpecMetadata
 from nimoy.ast_tools.features import FeatureRegistrationTransformer
+from nimoy.runner.metadata import RunnerContext
 
 
 class SpecTransformer(ast.NodeTransformer):
-    def __init__(self, spec_location, spec_metadata) -> None:
+    def __init__(self, runner_context: RunnerContext, spec_location, spec_metadata: List) -> None:
         super().__init__()
+        self.runner_context = runner_context
         self.spec_location = spec_location
         self.spec_metadata = spec_metadata
 
@@ -20,7 +23,7 @@ class SpecTransformer(ast.NodeTransformer):
 
                 metadata = SpecMetadata(class_node.name)
                 self._register_spec(metadata)
-                FeatureRegistrationTransformer(self.spec_location, metadata).visit(class_node)
+                FeatureRegistrationTransformer(self.runner_context, self.spec_location, metadata).visit(class_node)
 
                 for feature_name in metadata.where_functions:
                     feature = next(

--- a/nimoy/runner/metadata.py
+++ b/nimoy/runner/metadata.py
@@ -1,0 +1,4 @@
+class RunnerContext:
+
+    def __init__(self, use_power_assertions: bool = False):
+        self.use_power_assertions = use_power_assertions

--- a/nimoy/runner/spec_loader.py
+++ b/nimoy/runner/spec_loader.py
@@ -1,9 +1,12 @@
 import ast
 
+from nimoy.runner.metadata import RunnerContext
+
 
 class SpecLoader:
-    def __init__(self, ast_chain) -> None:
+    def __init__(self, runner_context: RunnerContext, ast_chain) -> None:
         super().__init__()
+        self.runner_context = runner_context
         self.ast_chain = ast_chain
 
     def load(self, spec_locations_and_contents):
@@ -11,7 +14,7 @@ class SpecLoader:
             for spec_location, text in spec_locations_and_contents:
                 node = ast.parse(text, mode='exec')
 
-                metadata_of_specs_from_node = self.ast_chain.apply(spec_location, node)
+                metadata_of_specs_from_node = self.ast_chain.apply(self.runner_context, spec_location, node)
                 ast.fix_missing_locations(node)
                 compiled = compile(node, spec_location.spec_path, 'exec')
 

--- a/nimoy/spec_runner.py
+++ b/nimoy/spec_runner.py
@@ -3,6 +3,7 @@ import os
 
 from nimoy.ast_tools import ast_chain
 from nimoy.runner import fs_resource_reader
+from nimoy.runner.metadata import RunnerContext
 from nimoy.runner.spec_executor import SpecExecutor
 from nimoy.runner.spec_finder import SpecFinder
 from nimoy.runner.spec_loader import SpecLoader
@@ -11,33 +12,37 @@ from nimoy.runner.spec_reader import SpecReader
 
 class SpecRunner:
     def run(self, execution_framework):
-        spec_locations = SpecRunner._find_specs()
+        parser = argparse.ArgumentParser(prog='nimoy', description='Run a suite of Nimoy specs.')
+        parser.add_argument('--power-assertions', metavar='P', type=bool, nargs=1, default=False,
+                            help="Should Nimoy evaluate comparison expressions using power assertions (alpha)")
+        parser.add_argument('specs', metavar='S', type=str, nargs='*',
+                            help="""A path to a spec file to execute or a directory to scan for spec files.
+                                    When naming a file it is possible to select which spec or feature to run. some_spec.py[::SpecName[::feature_name]]
+                                    """)
+
+        args = parser.parse_args()
+
+        spec_locations = SpecRunner._find_specs(args)
         spec_locations_and_contents = SpecRunner._read_specs(spec_locations)
-        return SpecRunner._run_on_contents(execution_framework, spec_locations_and_contents)
+        return SpecRunner._run_on_contents(RunnerContext(use_power_assertions=args.power_assertions),
+                                           execution_framework, spec_locations_and_contents)
 
     @staticmethod
-    def _run_on_contents(execution_framework, spec_locations_and_contents):
-        specs = SpecRunner._load_specs(spec_locations_and_contents)
+    def _run_on_contents(runner_context: RunnerContext, execution_framework, spec_locations_and_contents):
+        specs = SpecRunner._load_specs(runner_context, spec_locations_and_contents)
         return SpecRunner._execute_specs(execution_framework, specs)
 
     @staticmethod
-    def _find_specs():
-        parser = argparse.ArgumentParser(prog='nimoy', description='Run a suite of Nimoy specs.')
-        parser.add_argument('specs', metavar='S', type=str, nargs='*',
-                            help="""A path to a spec file to execute or a directory to scan for spec files.
-                            When naming a file it is possible to select which spec or feature to run. some_spec.py[::SpecName[::feature_name]]
-                            """)
-        args = parser.parse_args()
-        suggested_locations = args.specs
-        return SpecFinder(os.getcwd()).find(suggested_locations)
+    def _find_specs(args):
+        return SpecFinder(os.getcwd()).find(args.specs)
 
     @staticmethod
     def _read_specs(spec_locations):
         return SpecReader(fs_resource_reader).read(spec_locations)
 
     @staticmethod
-    def _load_specs(spec_locations_and_contents):
-        return SpecLoader(ast_chain).load(spec_locations_and_contents)
+    def _load_specs(runner_context: RunnerContext, spec_locations_and_contents):
+        return SpecLoader(runner_context, ast_chain).load(spec_locations_and_contents)
 
     @staticmethod
     def _execute_specs(execution_framework, specs):

--- a/nimoy/specification.py
+++ b/nimoy/specification.py
@@ -1,9 +1,11 @@
+from typing import Dict
 from unittest import TestCase
 import copy
 from nimoy.context.feature_block_context import FeatureBlock
 from nimoy.compare.internal import Compare
 from nimoy.assertions.mocks import MockAssertions
 from nimoy.assertions.exceptions import ExceptionAssertions
+from nimoy.assertions.power import PowerAssertions
 
 
 class DataDrivenSpecification(type):
@@ -63,6 +65,9 @@ class Specification(TestCase, metaclass=DataDrivenSpecification):
 
     def _compare(self, left, right, comparison_type_name):
         Compare().compare(left, right, comparison_type_name)
+
+    def _power_assert(self, expression: Dict):
+        PowerAssertions().assert_and_raise(expression)
 
     def _assert_mock(self, number_of_invocations, mock, method, *args):
         MockAssertions().assert_mock(number_of_invocations, mock, method, *args)

--- a/specs/nimoy/assertions/power_spec.py
+++ b/specs/nimoy/assertions/power_spec.py
@@ -1,0 +1,131 @@
+from nimoy.assertions.power import PowerAssertions, Variable, ConstantValue
+from nimoy.compare.types import Types
+from nimoy.specification import Specification
+
+
+class PowerAssertionsSpec(Specification):
+
+    def render_a_single_level_assertion_with_constant_on_the_right(self):
+        with setup:
+            left = [Variable('my_var', 2)]
+            right = [ConstantValue(3)]
+            expected = """Assertion failed:
+            my_var == 3
+            |      |
+            2      false
+            """
+        with when:
+            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+        with then:
+            rendered == expected
+
+    def render_a_single_level_assertion_with_constant_on_the_left(self):
+        with setup:
+            left = [Variable('my_var', 2)]
+            right = [ConstantValue(3)]
+            expected = """Assertion failed:
+            3 == my_var
+              |  |
+              |  2
+              false
+            """
+        with when:
+            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+        with then:
+            rendered == expected
+
+    def render_a_single_level_assertion(self):
+        with setup:
+            left = [Variable('my_var', 2)]
+            right = [Variable('my_var_2', 3)]
+            expected = """Assertion failed:
+            my_var == my_var_2
+            |      |  |
+            |      |  3
+            2      false
+            """
+        with when:
+            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+        with then:
+            rendered == expected
+
+    def render_a_multi_level_assertion(self):
+        with setup:
+            left = [Variable('my_var', {'moo': 'bob'}), Variable('my_field', 2)]
+            right = [Variable('my_var_2', {'bob': 'mcbob'}), Variable('my_field_2', 3)]
+            expected = """Assertion failed:
+            my_var.my_field == my_var_2.my_field_2
+            |      |        |  |        |
+            |      |        |  |        3
+            |      |        |  {bob:mcbob}
+            |      2        false
+            {moo: bob}  
+            """
+        with when:
+            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+        with then:
+            rendered == expected
+
+    def render_a_multi_level_assertion_with_constant_on_the_right(self):
+        with setup:
+            left = [Variable('my_var', {'moo': 'bob'}), Variable('my_field', 2)]
+            right = [ConstantValue(3)]
+            expected = """Assertion failed:
+            my_var.my_field == 3
+            |      |        |
+            |      2        false
+            {moo: bob}  
+            """
+        with when:
+            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+        with then:
+            rendered == expected
+
+    def render_a_multi_level_assertion_with_constant_on_the_left(self):
+        with setup:
+            left = [ConstantValue(3)]
+            right = [Variable('my_var', {'moo': 'bob'}), Variable('my_field', 2)]
+            expected = """Assertion failed:
+            3 == my_var.my_field
+              |  |      |
+              |  |      2
+              |  {moo: bob}
+              false
+            """
+        with when:
+            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+        with then:
+            rendered == expected
+
+    def render_a_left_lopsided_assertion(self):
+        with setup:
+            left = [Variable('my_var', {'moo': 'bob'}), Variable('my_field', 2)]
+            right = [Variable('my_var_2', {'bob': 'mcbob'})]
+            expected = """Assertion failed:
+            my_var.my_field == my_var_2
+            |      |        |  |
+            |      |        |  {bob:mcbob}
+            |      2        false      
+            {moo: bob}  
+            """
+        with when:
+            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+        with then:
+            rendered == expected
+
+    def render_a_right_lopsided_assertion(self):
+        with setup:
+            left = [Variable('my_var', {'moo': 'bob'})]
+            right = [Variable('my_var_2', {'bob': 'mcbob'}), Variable('my_field_2', 3)]
+            expected = """Assertion failed:
+            my_var == my_var_2.my_field_2
+            |      |  |        |
+            |      |  |        3
+            |      |  {bob:mcbob}         
+            |      false      
+            {moo: bob}  
+            """
+        with when:
+            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+        with then:
+            rendered == expected

--- a/specs/nimoy/assertions/power_spec.py
+++ b/specs/nimoy/assertions/power_spec.py
@@ -1,208 +1,252 @@
 import ast
 import _ast
+from typing import Dict
 
-from nimoy.assertions.power import PowerAssertions, Expression, Op
+from nimoy.assertions.power import PowerAssertions
 from nimoy.specification import Specification
 
 
-def _ast_to_nimoy_expression(ast_object) -> Expression:
+def _ast_to_nimoy_expression(ast_object) -> Dict:
     if type(ast_object) is _ast.Name:
-        return Expression(ast_object.id, '', ast_object.col_offset, ast_object.end_col_offset - 1)
+        return {'type': 'exp', 'name': ast_object.id, 'value': '', 'column': ast_object.col_offset,
+                'end_column': ast_object.end_col_offset - 1}
     elif type(ast_object) is _ast.Constant:
-        return Expression(str(ast_object.value), ast_object.value, ast_object.col_offset, ast_object.end_col_offset - 1,
-                          constant=True)
+        return {'type': 'exp', 'name': str(ast_object.value), 'value': ast_object.value,
+                'column': ast_object.col_offset,
+                'end_column': ast_object.end_col_offset - 1, 'constant': True}
     elif type(ast_object) is _ast.Attribute:
-        attribute_expression = Expression(ast_object.attr, '', ast_object.end_col_offset - len(ast_object.attr),
-                                          ast_object.end_col_offset - 1)
+        attribute_expression = {'type': 'exp', 'name': ast_object.attr, 'value': '', 'column': ast_object.value.end_col_offset + 1,
+                                'end_column': ast_object.end_col_offset - 1}
         parent_expression = _ast_to_nimoy_expression(ast_object.value)
-        parent_expression.next_node = attribute_expression
+        parent_expression['next'] = attribute_expression
         return parent_expression
 
 
-def _ast_op_to_nimoy_op(ast_object, assertion_result, latest_column) -> Op:
+def _ast_op_to_nimoy_op(ast_object, assertion_result: bool, latest_column) -> Dict:
+    start_column = latest_column + 1
+    end_column = start_column + 2
     op = None
     if type(ast_object) is _ast.Eq:
         op = '=='
-    return Op(assertion_result, op, latest_column + 2)
+    return {'type': 'op', 'op': op, 'value': assertion_result, 'column': start_column, 'end_column': end_column}
 
 
-def _assert_to_nimoy_expression(assert_expression: str, assertion_result: str) -> Expression:
+def _assert_to_nimoy_expression(assert_expression: str, assertion_result: bool) -> Dict:
     node = ast.parse(assert_expression, mode='exec')
     node_value = node.body[0].value
     left = node_value.left
     root_expression = _ast_to_nimoy_expression(left)
     current_expression = root_expression
-    while current_expression.next_node:
-        current_expression = current_expression.next_node
+    while 'next' in current_expression:
+        current_expression = current_expression['next']
 
-    current_expression.next_node = _ast_op_to_nimoy_op(node_value.ops[0], assertion_result,
-                                                       current_expression.end_column)
+    current_expression['next'] = _ast_op_to_nimoy_op(node_value.ops[0], assertion_result,
+                                                       left.end_col_offset)
 
-    current_expression = current_expression.next_node
+    current_expression = current_expression['next']
 
     right = node_value.comparators[0]
-    current_expression.next_node = _ast_to_nimoy_expression(right)
+    current_expression['next'] = _ast_to_nimoy_expression(right)
 
     return root_expression
 
 
 class PowerAssertionsSpec(Specification):
 
-    def render_a_single_level_assertion_with_constant_on_the_right(self):
+    def assert_a_correct_expression(self):
         with setup:
-            expression = _assert_to_nimoy_expression('my_var == 3', 'false')
-            expression.value = 2
+            expression = _assert_to_nimoy_expression('True == True', True)
+            assertions = PowerAssertions()
+        with expect:
+            assertions.assert_and_raise(expression)
+
+    def assert_a_wrong_expression(self):
+        with setup:
+            expression = _assert_to_nimoy_expression('my_var == 3', False)
+            expression['value'] = 2
 
             expected = """Assertion failed:
 my_var == 3
 |      |
-2      false
+2      False
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(expression)
+            rendered = assertions.render(expression)
+        with then:
+            rendered == expected
+
+    def render_a_single_level_assertion_with_constant_on_the_right(self):
+        with setup:
+            expression = _assert_to_nimoy_expression('my_var == 3', False)
+            expression['value'] = 2
+
+            expected = """Assertion failed:
+my_var == 3
+|      |
+2      False
+"""
+            assertions = PowerAssertions()
+        with when:
+            rendered = assertions.render(expression)
+        with then:
+            rendered == expected
+
+    def render_a_single_level_assertion_with_constant_on_the_right(self):
+        with setup:
+            expression = _assert_to_nimoy_expression('my_var == 3', False)
+            expression['value'] = 2
+
+            expected = """Assertion failed:
+my_var == 3
+|      |
+2      False
+"""
+            assertions = PowerAssertions()
+        with when:
+            rendered = assertions.render(expression)
         with then:
             rendered == expected
 
     def render_a_single_level_assertion_with_constant_on_the_left(self):
         with setup:
-            expression = _assert_to_nimoy_expression('3 == my_var', 'false')
-            expression.next_node.next_node.value = 2
+            expression = _assert_to_nimoy_expression('3 == my_var', False)
+            expression['next']['next']['value'] = 2
 
             expected = """Assertion failed:
 3 == my_var
   |  |
   |  2
-  false
+  False
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(expression)
+            rendered = assertions.render(expression)
         with then:
             rendered == expected
 
     def render_a_single_level_assertion(self):
         with setup:
-            expression = _assert_to_nimoy_expression('my_var == my_var_2', 'false')
-            expression.value = 2
-            expression.next_node.next_node.value = 3
+            expression = _assert_to_nimoy_expression('my_var == my_var_2', False)
+            expression['value'] = 2
+            expression['next']['next']['value'] = 3
 
             expected = """Assertion failed:
 my_var == my_var_2
 |      |  |
 |      |  3
-2      false
+2      False
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(expression)
+            rendered = assertions.render(expression)
         with then:
             rendered == expected
 
     def render_a_multi_level_assertion(self):
         with setup:
-            expression = _assert_to_nimoy_expression('my_var.my_field == my_var_2.my_field_2', 'false')
-            expression.value = {'moo': 'bob'}
-            expression.next_node.value = 2
+            expression = _assert_to_nimoy_expression('my_var.my_field == my_var_2.my_field_2', False)
+            expression['value'] = {'moo': 'bob'}
+            expression['next']['value'] = 2
 
-            expression.next_node.next_node.next_node.value = {'bob': 'mcbob'}
-            expression.next_node.next_node.next_node.next_node.value = 3
+            expression['next']['next']['next']['value'] = {'bob': 'mcbob'}
+            expression['next']['next']['next']['next']['value'] = 3
 
             expected = """Assertion failed:
 my_var.my_field == my_var_2.my_field_2
 |      |        |  |        |
 |      |        |  |        3
 |      |        |  {'bob': 'mcbob'}
-|      2        false
+|      2        False
 {'moo': 'bob'}
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(expression)
+            rendered = assertions.render(expression)
         with then:
             rendered == expected
 
     def render_a_multi_level_assertion_with_constant_on_the_right(self):
         with setup:
-            expression = _assert_to_nimoy_expression('my_var.my_field == 3', 'false')
-            expression.value = {'moo': 'bob'}
-            expression.next_node.value = 2
+            expression = _assert_to_nimoy_expression('my_var.my_field == 3', False)
+            expression['value'] = {'moo': 'bob'}
+            expression['next']['value'] = 2
 
             expected = """Assertion failed:
 my_var.my_field == 3
 |      |        |
-|      2        false
+|      2        False
 {'moo': 'bob'}
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(expression)
+            rendered = assertions.render(expression)
         with then:
             rendered == expected
 
     def render_a_multi_level_assertion_with_constant_on_the_left(self):
         with setup:
-            expression = _assert_to_nimoy_expression('3 == my_var.my_field', 'false')
+            expression = _assert_to_nimoy_expression('3 == my_var.my_field', False)
 
-            expression.value = 3
+            expression['value'] = 3
 
-            expression.next_node.next_node.value = {'moo': 'bob'}
-            expression.next_node.next_node.next_node.value = 2
+            expression['next']['next']['value'] = {'moo': 'bob'}
+            expression['next']['next']['next']['value'] = 2
 
             expected = """Assertion failed:
 3 == my_var.my_field
   |  |      |
   |  |      2
   |  {'moo': 'bob'}
-  false
+  False
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(expression)
+            rendered = assertions.render(expression)
         with then:
             rendered == expected
 
     def render_a_left_lopsided_assertion(self):
         with setup:
-            expression = _assert_to_nimoy_expression('my_var.my_field == my_var_2', 'false')
+            expression = _assert_to_nimoy_expression('my_var.my_field == my_var_2', False)
 
-            expression.value = {'moo': 'bob'}
-            expression.next_node.value = 2
+            expression['value'] = {'moo': 'bob'}
+            expression['next']['value'] = 2
 
-            expression.next_node.next_node.next_node.value = {'bob': 'mcbob'}
+            expression['next']['next']['next']['value'] = {'bob': 'mcbob'}
 
             expected = """Assertion failed:
 my_var.my_field == my_var_2
 |      |        |  |
 |      |        |  {'bob': 'mcbob'}
-|      2        false
+|      2        False
 {'moo': 'bob'}
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(expression)
+            rendered = assertions.render(expression)
         with then:
             rendered == expected
 
     def render_a_right_lopsided_assertion(self):
         with setup:
-            expression = _assert_to_nimoy_expression('my_var == my_var_2.my_field_2', 'false')
+            expression = _assert_to_nimoy_expression('my_var == my_var_2.my_field_2', False)
 
-            expression.value = {'moo': 'bob'}
+            expression['value'] = {'moo': 'bob'}
 
-            expression.next_node.next_node.value = {'bob': 'mcbob'}
-            expression.next_node.next_node.next_node.value = 3
+            expression['next']['next']['value'] = {'bob': 'mcbob'}
+            expression['next']['next']['next']['value'] = 3
 
             expected = """Assertion failed:
 my_var == my_var_2.my_field_2
 |      |  |        |
 |      |  |        3
 |      |  {'bob': 'mcbob'}
-|      false
+|      False
 {'moo': 'bob'}
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(expression)
+            rendered = assertions.render(expression)
         with then:
             rendered == expected

--- a/specs/nimoy/assertions/power_spec.py
+++ b/specs/nimoy/assertions/power_spec.py
@@ -1,53 +1,74 @@
 import ast
 import _ast
 
-from nimoy.assertions.power import PowerAssertions, Expression, Assertion, Op
-from nimoy.compare.types import Types
+from nimoy.assertions.power import PowerAssertions, Expression, Op
 from nimoy.specification import Specification
 
 
-def assert_to_assertion(assert_expression: str) -> Assertion:
+def _ast_to_nimoy_expression(ast_object) -> Expression:
+    if type(ast_object) is _ast.Name:
+        return Expression(ast_object.id, '', ast_object.col_offset, ast_object.end_col_offset - 1)
+    elif type(ast_object) is _ast.Constant:
+        return Expression(str(ast_object.value), ast_object.value, ast_object.col_offset, ast_object.end_col_offset - 1,
+                          constant=True)
+    elif type(ast_object) is _ast.Attribute:
+        attribute_expression = Expression(ast_object.attr, '', ast_object.end_col_offset - len(ast_object.attr),
+                                          ast_object.end_col_offset - 1)
+        parent_expression = _ast_to_nimoy_expression(ast_object.value)
+        parent_expression.next_node = attribute_expression
+        return parent_expression
+
+
+def _ast_op_to_nimoy_op(ast_object, assertion_result, latest_column) -> Op:
+    op = None
+    if type(ast_object) is _ast.Eq:
+        op = '=='
+    return Op(assertion_result, op, latest_column + 2)
+
+
+def _assert_to_nimoy_expression(assert_expression: str, assertion_result: str) -> Expression:
     node = ast.parse(assert_expression, mode='exec')
     node_value = node.body[0].value
     left = node_value.left
-    if type(left) is _ast.Name:
-        left_expression = Expression(left.id, '', left.col_offset)
-    elif type(left) is _ast.Constant:
-        left_expression = Expression(str(left.value), left.value, left.col_offset, constant=True)
+    root_expression = _ast_to_nimoy_expression(left)
+    current_expression = root_expression
+    while current_expression.next_node:
+        current_expression = current_expression.next_node
+
+    current_expression.next_node = _ast_op_to_nimoy_op(node_value.ops[0], assertion_result,
+                                                       current_expression.end_column)
+
+    current_expression = current_expression.next_node
 
     right = node_value.comparators[0]
-    if type(right) is _ast.Constant:
-        right_expression = Expression(str(right.value), right.value, right.col_offset, constant=True)
-    elif type(right) is _ast.Name:
-        right_expression = Expression(right.id, '', right.col_offset)
+    current_expression.next_node = _ast_to_nimoy_expression(right)
 
-    return Assertion(left_expression, right_expression, Op('==', Types.EQUAL))
+    return root_expression
 
 
 class PowerAssertionsSpec(Specification):
 
     def render_a_single_level_assertion_with_constant_on_the_right(self):
         with setup:
-            assertion = assert_to_assertion('my_var == 3')
-            assertion.left.value = 2
+            expression = _assert_to_nimoy_expression('my_var == 3', 'false')
+            expression.value = 2
 
-            assertion.op.value = 'false'
             expected = """Assertion failed:
 my_var == 3
 |      |
 2      false
 """
+            assertions = PowerAssertions()
         with when:
-            rendered = PowerAssertions().assert_and_render(assertion)
+            rendered = assertions.assert_and_render(expression)
         with then:
             rendered == expected
 
     def render_a_single_level_assertion_with_constant_on_the_left(self):
         with setup:
-            assertion = assert_to_assertion('3 == my_var')
-            assertion.right.value = 2
+            expression = _assert_to_nimoy_expression('3 == my_var', 'false')
+            expression.next_node.next_node.value = 2
 
-            assertion.op.value = 'false'
             expected = """Assertion failed:
 3 == my_var
   |  |
@@ -56,15 +77,16 @@ my_var == 3
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(assertion)
+            rendered = assertions.assert_and_render(expression)
         with then:
             rendered == expected
 
     def render_a_single_level_assertion(self):
         with setup:
-            left = Expression('my_var', 2)
-            right = Expression('my_var_2', 3)
-            assertion = Assertion(left, right, Op('==', Types.EQUAL))
+            expression = _assert_to_nimoy_expression('my_var == my_var_2', 'false')
+            expression.value = 2
+            expression.next_node.next_node.value = 3
+
             expected = """Assertion failed:
 my_var == my_var_2
 |      |  |
@@ -73,92 +95,114 @@ my_var == my_var_2
 """
             assertions = PowerAssertions()
         with when:
-            rendered = assertions.assert_and_render(assertion)
+            rendered = assertions.assert_and_render(expression)
         with then:
             rendered == expected
 
     def render_a_multi_level_assertion(self):
         with setup:
-            left = Expression('my_var', {'moo': 'bob'}, next_node=Expression('my_field', 2))
-            right = Expression('my_var_2', {'bob': 'mcbob'}, next_node=Expression('my_field_2', 3))
-            assertion = Assertion(left, right, Op('==', Types.EQUAL))
+            expression = _assert_to_nimoy_expression('my_var.my_field == my_var_2.my_field_2', 'false')
+            expression.value = {'moo': 'bob'}
+            expression.next_node.value = 2
+
+            expression.next_node.next_node.next_node.value = {'bob': 'mcbob'}
+            expression.next_node.next_node.next_node.next_node.value = 3
+
             expected = """Assertion failed:
 my_var.my_field == my_var_2.my_field_2
 |      |        |  |        |
 |      |        |  |        3
-|      |        |  {bob:mcbob}
+|      |        |  {'bob': 'mcbob'}
 |      2        false
-{moo: bob}  
+{'moo': 'bob'}
 """
+            assertions = PowerAssertions()
         with when:
-            rendered = PowerAssertions().assert_and_render(assertion)
+            rendered = assertions.assert_and_render(expression)
         with then:
             rendered == expected
 
     def render_a_multi_level_assertion_with_constant_on_the_right(self):
         with setup:
-            left = Expression('my_var', {'moo': 'bob'}, next_node=Expression('my_field', 2))
-            right = Expression('3', 3)
-            assertion = Assertion(left, right, Op('==', Types.EQUAL))
+            expression = _assert_to_nimoy_expression('my_var.my_field == 3', 'false')
+            expression.value = {'moo': 'bob'}
+            expression.next_node.value = 2
+
             expected = """Assertion failed:
 my_var.my_field == 3
 |      |        |
 |      2        false
-{moo: bob}  
+{'moo': 'bob'}
 """
+            assertions = PowerAssertions()
         with when:
-            rendered = PowerAssertions().assert_and_render(assertion)
+            rendered = assertions.assert_and_render(expression)
         with then:
             rendered == expected
 
     def render_a_multi_level_assertion_with_constant_on_the_left(self):
         with setup:
-            left = Expression('3', 3)
-            right = Expression('my_var', {'moo': 'bob'}, next_node=Expression('my_field', 2))
-            assertion = Assertion(left, right, Op('==', Types.EQUAL))
+            expression = _assert_to_nimoy_expression('3 == my_var.my_field', 'false')
+
+            expression.value = 3
+
+            expression.next_node.next_node.value = {'moo': 'bob'}
+            expression.next_node.next_node.next_node.value = 2
+
             expected = """Assertion failed:
 3 == my_var.my_field
   |  |      |
   |  |      2
-  |  {moo: bob}
+  |  {'moo': 'bob'}
   false
 """
+            assertions = PowerAssertions()
         with when:
-            rendered = PowerAssertions().assert_and_render(assertion)
+            rendered = assertions.assert_and_render(expression)
         with then:
             rendered == expected
 
     def render_a_left_lopsided_assertion(self):
         with setup:
-            left = Expression('my_var', {'moo': 'bob'}, next_node=Expression('my_field', 2))
-            right = Expression('my_var_2', {'bob': 'mcbob'})
-            assertion = Assertion(left, right, Op('==', Types.EQUAL))
+            expression = _assert_to_nimoy_expression('my_var.my_field == my_var_2', 'false')
+
+            expression.value = {'moo': 'bob'}
+            expression.next_node.value = 2
+
+            expression.next_node.next_node.next_node.value = {'bob': 'mcbob'}
+
             expected = """Assertion failed:
 my_var.my_field == my_var_2
 |      |        |  |
-|      |        |  {bob:mcbob}
-|      2        false      
-{moo: bob}  
+|      |        |  {'bob': 'mcbob'}
+|      2        false
+{'moo': 'bob'}
 """
+            assertions = PowerAssertions()
         with when:
-            rendered = PowerAssertions().assert_and_render(assertion)
+            rendered = assertions.assert_and_render(expression)
         with then:
             rendered == expected
 
     def render_a_right_lopsided_assertion(self):
         with setup:
-            left = Expression('my_var', {'moo': 'bob'})
-            right = Expression('my_var_2', {'bob': 'mcbob'}, next_node=Expression('my_field_2', 3))
-            assertion = Assertion(left, right, Op('==', Types.EQUAL))
+            expression = _assert_to_nimoy_expression('my_var == my_var_2.my_field_2', 'false')
+
+            expression.value = {'moo': 'bob'}
+
+            expression.next_node.next_node.value = {'bob': 'mcbob'}
+            expression.next_node.next_node.next_node.value = 3
+
             expected = """Assertion failed:
 my_var == my_var_2.my_field_2
 |      |  |        |
 |      |  |        3
-|      |  {bob:mcbob}         
-|      false      
-{moo: bob}  
+|      |  {'bob': 'mcbob'}
+|      false
+{'moo': 'bob'}
 """
+            assertions = PowerAssertions()
         with when:
-            rendered = PowerAssertions().assert_and_render(assertion)
+            rendered = assertions.assert_and_render(expression)
         with then:
             rendered == expected

--- a/specs/nimoy/assertions/power_spec.py
+++ b/specs/nimoy/assertions/power_spec.py
@@ -1,131 +1,164 @@
-from nimoy.assertions.power import PowerAssertions, Variable, ConstantValue
+import ast
+import _ast
+
+from nimoy.assertions.power import PowerAssertions, Expression, Assertion, Op
 from nimoy.compare.types import Types
 from nimoy.specification import Specification
+
+
+def assert_to_assertion(assert_expression: str) -> Assertion:
+    node = ast.parse(assert_expression, mode='exec')
+    node_value = node.body[0].value
+    left = node_value.left
+    if type(left) is _ast.Name:
+        left_expression = Expression(left.id, '', left.col_offset)
+    elif type(left) is _ast.Constant:
+        left_expression = Expression(str(left.value), left.value, left.col_offset, constant=True)
+
+    right = node_value.comparators[0]
+    if type(right) is _ast.Constant:
+        right_expression = Expression(str(right.value), right.value, right.col_offset, constant=True)
+    elif type(right) is _ast.Name:
+        right_expression = Expression(right.id, '', right.col_offset)
+
+    return Assertion(left_expression, right_expression, Op('==', Types.EQUAL))
 
 
 class PowerAssertionsSpec(Specification):
 
     def render_a_single_level_assertion_with_constant_on_the_right(self):
         with setup:
-            left = [Variable('my_var', 2)]
-            right = [ConstantValue(3)]
+            assertion = assert_to_assertion('my_var == 3')
+            assertion.left.value = 2
+
+            assertion.op.value = 'false'
             expected = """Assertion failed:
-            my_var == 3
-            |      |
-            2      false
-            """
+my_var == 3
+|      |
+2      false
+"""
         with when:
-            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+            rendered = PowerAssertions().assert_and_render(assertion)
         with then:
             rendered == expected
 
     def render_a_single_level_assertion_with_constant_on_the_left(self):
         with setup:
-            left = [Variable('my_var', 2)]
-            right = [ConstantValue(3)]
+            assertion = assert_to_assertion('3 == my_var')
+            assertion.right.value = 2
+
+            assertion.op.value = 'false'
             expected = """Assertion failed:
-            3 == my_var
-              |  |
-              |  2
-              false
-            """
+3 == my_var
+  |  |
+  |  2
+  false
+"""
+            assertions = PowerAssertions()
         with when:
-            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+            rendered = assertions.assert_and_render(assertion)
         with then:
             rendered == expected
 
     def render_a_single_level_assertion(self):
         with setup:
-            left = [Variable('my_var', 2)]
-            right = [Variable('my_var_2', 3)]
+            left = Expression('my_var', 2)
+            right = Expression('my_var_2', 3)
+            assertion = Assertion(left, right, Op('==', Types.EQUAL))
             expected = """Assertion failed:
-            my_var == my_var_2
-            |      |  |
-            |      |  3
-            2      false
-            """
+my_var == my_var_2
+|      |  |
+|      |  3
+2      false
+"""
+            assertions = PowerAssertions()
         with when:
-            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+            rendered = assertions.assert_and_render(assertion)
         with then:
             rendered == expected
 
     def render_a_multi_level_assertion(self):
         with setup:
-            left = [Variable('my_var', {'moo': 'bob'}), Variable('my_field', 2)]
-            right = [Variable('my_var_2', {'bob': 'mcbob'}), Variable('my_field_2', 3)]
+            left = Expression('my_var', {'moo': 'bob'}, next_node=Expression('my_field', 2))
+            right = Expression('my_var_2', {'bob': 'mcbob'}, next_node=Expression('my_field_2', 3))
+            assertion = Assertion(left, right, Op('==', Types.EQUAL))
             expected = """Assertion failed:
-            my_var.my_field == my_var_2.my_field_2
-            |      |        |  |        |
-            |      |        |  |        3
-            |      |        |  {bob:mcbob}
-            |      2        false
-            {moo: bob}  
-            """
+my_var.my_field == my_var_2.my_field_2
+|      |        |  |        |
+|      |        |  |        3
+|      |        |  {bob:mcbob}
+|      2        false
+{moo: bob}  
+"""
         with when:
-            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+            rendered = PowerAssertions().assert_and_render(assertion)
         with then:
             rendered == expected
 
     def render_a_multi_level_assertion_with_constant_on_the_right(self):
         with setup:
-            left = [Variable('my_var', {'moo': 'bob'}), Variable('my_field', 2)]
-            right = [ConstantValue(3)]
+            left = Expression('my_var', {'moo': 'bob'}, next_node=Expression('my_field', 2))
+            right = Expression('3', 3)
+            assertion = Assertion(left, right, Op('==', Types.EQUAL))
             expected = """Assertion failed:
-            my_var.my_field == 3
-            |      |        |
-            |      2        false
-            {moo: bob}  
-            """
+my_var.my_field == 3
+|      |        |
+|      2        false
+{moo: bob}  
+"""
         with when:
-            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+            rendered = PowerAssertions().assert_and_render(assertion)
         with then:
             rendered == expected
 
     def render_a_multi_level_assertion_with_constant_on_the_left(self):
         with setup:
-            left = [ConstantValue(3)]
-            right = [Variable('my_var', {'moo': 'bob'}), Variable('my_field', 2)]
+            left = Expression('3', 3)
+            right = Expression('my_var', {'moo': 'bob'}, next_node=Expression('my_field', 2))
+            assertion = Assertion(left, right, Op('==', Types.EQUAL))
             expected = """Assertion failed:
-            3 == my_var.my_field
-              |  |      |
-              |  |      2
-              |  {moo: bob}
-              false
-            """
+3 == my_var.my_field
+  |  |      |
+  |  |      2
+  |  {moo: bob}
+  false
+"""
         with when:
-            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+            rendered = PowerAssertions().assert_and_render(assertion)
         with then:
             rendered == expected
 
     def render_a_left_lopsided_assertion(self):
         with setup:
-            left = [Variable('my_var', {'moo': 'bob'}), Variable('my_field', 2)]
-            right = [Variable('my_var_2', {'bob': 'mcbob'})]
+            left = Expression('my_var', {'moo': 'bob'}, next_node=Expression('my_field', 2))
+            right = Expression('my_var_2', {'bob': 'mcbob'})
+            assertion = Assertion(left, right, Op('==', Types.EQUAL))
             expected = """Assertion failed:
-            my_var.my_field == my_var_2
-            |      |        |  |
-            |      |        |  {bob:mcbob}
-            |      2        false      
-            {moo: bob}  
-            """
+my_var.my_field == my_var_2
+|      |        |  |
+|      |        |  {bob:mcbob}
+|      2        false      
+{moo: bob}  
+"""
         with when:
-            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+            rendered = PowerAssertions().assert_and_render(assertion)
         with then:
             rendered == expected
 
     def render_a_right_lopsided_assertion(self):
         with setup:
-            left = [Variable('my_var', {'moo': 'bob'})]
-            right = [Variable('my_var_2', {'bob': 'mcbob'}), Variable('my_field_2', 3)]
+            left = Expression('my_var', {'moo': 'bob'})
+            right = Expression('my_var_2', {'bob': 'mcbob'}, next_node=Expression('my_field_2', 3))
+            assertion = Assertion(left, right, Op('==', Types.EQUAL))
             expected = """Assertion failed:
-            my_var == my_var_2.my_field_2
-            |      |  |        |
-            |      |  |        3
-            |      |  {bob:mcbob}         
-            |      false      
-            {moo: bob}  
-            """
+my_var == my_var_2.my_field_2
+|      |  |        |
+|      |  |        3
+|      |  {bob:mcbob}         
+|      false      
+{moo: bob}  
+"""
         with when:
-            rendered = PowerAssertions().assert_and_render(left, right, Types.EQUAL)
+            rendered = PowerAssertions().assert_and_render(assertion)
         with then:
             rendered == expected

--- a/specs/nimoy/ast_tools/ast_chain_spec.py
+++ b/specs/nimoy/ast_tools/ast_chain_spec.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from nimoy.ast_tools import ast_chain
+from nimoy.runner.metadata import RunnerContext
 from nimoy.runner.spec_finder import Location
 from nimoy.specification import Specification
 
@@ -12,7 +13,7 @@ class AstChainSpec(Specification):
         with given:
             node = {}
         with when:
-            spec_metadata = ast_chain.apply(Location('some_spec.py'), node)
+            spec_metadata = ast_chain.apply(RunnerContext(), Location('some_spec.py'), node)
         with then:
             isinstance(spec_metadata, list) == True
             1 * spec_transformer_mock.return_value.visit(node)

--- a/specs/nimoy/ast_tools/expression_transformer_spec.py
+++ b/specs/nimoy/ast_tools/expression_transformer_spec.py
@@ -1,8 +1,239 @@
 import ast
 import _ast
+from _ast import Dict, Constant, Name, Attribute
+
+import astor
+
 from nimoy.specification import Specification
 from nimoy.ast_tools.expression_transformer import ComparisonExpressionTransformer, ThrownExpressionTransformer, \
-    MockBehaviorExpressionTransformer
+    MockBehaviorExpressionTransformer, PowerAssertionTransformer
+
+
+class PowerAssertionTransformerSpec(Specification):
+
+    def non_assertion_expressions_are_returned(self):
+        with given:
+            expression = """jim = 'bob'"""
+            node = ast.parse(expression, mode='exec')
+            transformed = PowerAssertionTransformer().visit_Call(node.body[0])
+        with expect:
+            node.body[0] == transformed
+
+    def assertion_expressions_are_transformed(self):
+        with given:
+            expression = """True == 2"""
+            node = ast.parse(expression, mode='exec')
+            transformed = PowerAssertionTransformer().visit_Call(node.body[0])
+            node.body[0] = transformed
+        with expect:
+            astor.to_source(node) != None  # sanity check to make sure that the produced node is valid AST
+            transformed.value.func.attr == '_power_assert'
+            transformed.value.func.value.id == 'self'
+            left_keys = transformed.value.args[0].keys
+            left_keys[0].value == 'type'
+            left_keys[1].value == 'name'
+            left_keys[2].value == 'value'
+            left_keys[3].value == 'column'
+            left_keys[4].value == 'end_column'
+            left_keys[5].value == 'constant'
+            left_keys[6].value == 'next'
+
+            left_values = transformed.value.args[0].values
+            left_values[0].value == 'exp'
+            left_values[1].value == 'True'
+            left_values[2].value == True
+            left_values[3].value == 0
+            left_values[4].value == 3
+            left_values[5].value == True
+
+            op = left_values[6]
+            op_keys = op.keys
+            op_keys[0].value == 'type'
+            op_keys[1].value == 'value'
+            op_keys[2].value == 'op'
+            op_keys[3].value == 'column'
+            op_keys[4].value == 'next'
+
+            op_values = op.values
+            op_values[0].value == 'op'
+            type(op_values[1]) == _ast.Compare
+            op_values[2].value == '=='
+            op_values[3].value == 5
+
+            right_keys = op_values[4].keys
+            right_keys[0].value == 'type'
+            right_keys[1].value == 'name'
+            right_keys[2].value == 'value'
+            right_keys[3].value == 'column'
+            right_keys[4].value == 'end_column'
+            right_keys[5].value == 'constant'
+
+            right_values = op_values[4].values
+            right_values[0].value == 'exp'
+            right_values[1].value == '2'
+            right_values[2].value == 2
+            right_values[3].value == 8
+            right_values[4].value == 8
+            right_values[5].value == True
+
+    def convert_assertion_ast_to_nimoy_expression_ast(self):
+        with given:
+            expression = """True == 2"""
+            node = ast.parse(expression, mode='exec')
+            transformed = PowerAssertionTransformer().assert_ast_to_nimoy_expression_ast(node.body[0].value)
+        with expect:
+            left_keys = transformed.keys
+            left_keys[0].value == 'type'
+            left_keys[1].value == 'name'
+            left_keys[2].value == 'value'
+            left_keys[3].value == 'column'
+            left_keys[4].value == 'end_column'
+            left_keys[5].value == 'constant'
+            left_keys[6].value == 'next'
+
+            left_values = transformed.values
+            left_values[0].value == 'exp'
+            left_values[1].value == 'True'
+            left_values[2].value == True
+            left_values[3].value == 0
+            left_values[4].value == 3
+            left_values[5].value == True
+
+            op = left_values[6]
+            op_keys = op.keys
+            op_keys[0].value == 'type'
+            op_keys[1].value == 'value'
+            op_keys[2].value == 'op'
+            op_keys[3].value == 'column'
+            op_keys[4].value == 'next'
+
+            op_values = op.values
+            op_values[0].value == 'op'
+            type(op_values[1]) == _ast.Compare
+            op_values[2].value == '=='
+            op_values[3].value == 5
+
+            right_keys = op_values[4].keys
+            right_keys[0].value == 'type'
+            right_keys[1].value == 'name'
+            right_keys[2].value == 'value'
+            right_keys[3].value == 'column'
+            right_keys[4].value == 'end_column'
+            right_keys[5].value == 'constant'
+
+            right_values = op_values[4].values
+            right_values[0].value == 'exp'
+            right_values[1].value == '2'
+            right_values[2].value == 2
+            right_values[3].value == 8
+            right_values[4].value == 8
+            right_values[5].value == True
+
+    def convert_eq_op_ast_to_nimoy_op_ast(self):
+        with given:
+            expression = """True == 2"""
+            node = ast.parse(expression, mode='exec')
+            transformed = PowerAssertionTransformer().op_ast_to_nimoy_op_ast(node.body[0].value.ops[0], 5,
+                                                                             node.body[0].value)
+        with expect:
+            op_keys = transformed.keys
+            op_keys[0].value == 'type'
+            op_keys[1].value == 'value'
+            op_keys[2].value == 'op'
+            op_keys[3].value == 'column'
+
+            op_values = transformed.values
+            op_values[0].value == 'op'
+            type(op_values[1]) == _ast.Compare
+            op_values[2].value == '=='
+            op_values[3].value == 5
+
+    def get_last_dictionary(self):
+        with given:
+            leaf = Dict(keys=[Constant(value='leaf')], values=[Constant(value='value')])
+            branch = Dict(keys=[Constant(value='next')], values=[leaf])
+            root = Dict(keys=[Constant(value='next')], values=[branch])
+            rightmost = PowerAssertionTransformer().get_last_dictionary(root)
+        with expect:
+            rightmost.keys[0].value == 'leaf'
+
+    def name_node_ast_to_nimoy_expression_ast(self):
+        with given:
+            name_expression = Name(id='bob', col_offset=0, end_col_offset=10)
+            transformed_keys, transformed_values = PowerAssertionTransformer().expression_node_ast_to_nimoy_expression_ast(
+                name_expression)
+        with expect:
+            transformed_keys[0].value == 'type'
+            transformed_keys[1].value == 'name'
+            transformed_keys[2].value == 'value'
+            transformed_keys[3].value == 'column'
+            transformed_keys[4].value == 'end_column'
+            transformed_keys[5].value == 'constant'
+
+            transformed_values[0].value == 'exp'
+            transformed_values[1].value == 'bob'
+            transformed_values[2] == name_expression
+            transformed_values[3].value == 0
+            transformed_values[4].value == 9
+            transformed_values[5].value == False
+
+    def constant_node_ast_to_nimoy_expression_ast(self):
+        with given:
+            constant_expression = Constant(value='bob', col_offset=0, end_col_offset=10)
+            transformed_keys, transformed_values = PowerAssertionTransformer().expression_node_ast_to_nimoy_expression_ast(
+                constant_expression)
+        with expect:
+            transformed_keys[0].value == 'type'
+            transformed_keys[1].value == 'name'
+            transformed_keys[2].value == 'value'
+            transformed_keys[3].value == 'column'
+            transformed_keys[4].value == 'end_column'
+            transformed_keys[5].value == 'constant'
+
+            transformed_values[0].value == 'exp'
+            transformed_values[1].value == 'bob'
+            transformed_values[2] == constant_expression
+            transformed_values[3].value == 0
+            transformed_values[4].value == 9
+            transformed_values[5].value == True
+
+    def attribute_node_ast_to_nimoy_expression_ast(self):
+        with given:
+            name_expression = Name(id='bob', col_offset=0, end_col_offset=3)
+            attribute_expression = Attribute(attr='mcbob', col_offset=4, end_col_offset=10, value=name_expression)
+            transformed_keys, transformed_values = PowerAssertionTransformer().expression_node_ast_to_nimoy_expression_ast(
+                attribute_expression)
+        with expect:
+            transformed_keys[0].value == 'type'
+            transformed_keys[1].value == 'name'
+            transformed_keys[2].value == 'value'
+            transformed_keys[3].value == 'column'
+            transformed_keys[4].value == 'end_column'
+            transformed_keys[5].value == 'constant'
+            transformed_keys[6].value == 'next'
+
+            transformed_values[0].value == 'exp'
+            transformed_values[1].value == 'bob'
+            transformed_values[2] == name_expression
+            transformed_values[3].value == 0
+            transformed_values[4].value == 2
+            transformed_values[5].value == False
+
+            attribute_keys = transformed_values[6].keys
+            attribute_keys[0].value == 'type'
+            attribute_keys[1].value == 'name'
+            attribute_keys[2].value == 'value'
+            attribute_keys[3].value == 'column'
+            attribute_keys[4].value == 'end_column'
+            attribute_keys[5].value == 'constant'
+
+            attribute_values = transformed_values[6].values
+            attribute_values[0].value == 'exp'
+            attribute_values[1].value == 'mcbob'
+            attribute_values[2] == attribute_expression
+            attribute_values[3].value == 4
+            attribute_values[4].value == 9
+            attribute_values[5].value == False
 
 
 class ComparisonExpressionTransformerSpec(Specification):

--- a/specs/nimoy/ast_tools/feature_blocks_spec.py
+++ b/specs/nimoy/ast_tools/feature_blocks_spec.py
@@ -1,6 +1,8 @@
 import ast
 from unittest import mock
 import _ast
+
+from nimoy.runner.metadata import RunnerContext
 from nimoy.specification import Specification
 from nimoy.ast_tools.feature_blocks import FeatureBlockTransformer
 from nimoy.ast_tools.feature_blocks import FeatureBlockRuleEnforcer
@@ -175,7 +177,7 @@ class JimbobSpec(Specification):
             spec_metadata = get_basic_spec_metadata()
 
         with when:
-            FeatureBlockTransformer(spec_metadata, 'test_it').visit(node)
+            FeatureBlockTransformer(RunnerContext(), spec_metadata, 'test_it').visit(node)
 
         with then:
             spec_feature_body = node.body[1].body[0].body

--- a/specs/nimoy/ast_tools/features_spec.py
+++ b/specs/nimoy/ast_tools/features_spec.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from nimoy.ast_tools.ast_metadata import SpecMetadata
 from nimoy.ast_tools.features import FeatureRegistrationTransformer
+from nimoy.runner.metadata import RunnerContext
 from nimoy.runner.spec_finder import Location
 from nimoy.specification import Specification
 
@@ -13,6 +14,7 @@ class FeatureRegistrationTransformerSpec(Specification):
     @mock.patch('nimoy.ast_tools.features.FeatureBlockTransformer')
     def a_feature_was_added(self, feature_block_transformer, feature_block_rule_enforcer):
         with setup:
+            runner_context = RunnerContext()
             module_definition = """
 class JSpec:
     def test_jim(self):
@@ -25,13 +27,13 @@ class JSpec:
             metadata = SpecMetadata('jim')
 
         with when:
-            FeatureRegistrationTransformer(Location('some_spec.py'), metadata).visit(node)
+            FeatureRegistrationTransformer(runner_context, Location('some_spec.py'), metadata).visit(node)
 
         with then:
             len(metadata.features) == 1
             metadata.features[0] == 'test_jim'
 
-            feature_block_transformer.assert_called_once_with(metadata, 'test_jim')
+            feature_block_transformer.assert_called_once_with(runner_context, metadata, 'test_jim')
             1 * feature_block_transformer.return_value.visit(node.body[0].body[0])
 
             feature_block_rule_enforcer.assert_called_once_with(metadata, 'test_jim', node.body[0].body[0])
@@ -41,6 +43,7 @@ class JSpec:
     @mock.patch('nimoy.ast_tools.features.FeatureBlockTransformer')
     def only_the_specified_feature_was_added(self, feature_block_transformer, feature_block_rule_enforcer):
         with setup:
+            runner_context = RunnerContext()
             module_definition = """
 class JSpec:
     def test_jim(self):
@@ -55,13 +58,13 @@ class JSpec:
             metadata = SpecMetadata('jim')
 
         with when:
-            FeatureRegistrationTransformer(Location('some_spec.py::test_bob'), metadata).visit(node)
+            FeatureRegistrationTransformer(runner_context, Location('some_spec.py::test_bob'), metadata).visit(node)
 
         with then:
             len(metadata.features) == 1
             metadata.features[0] == 'test_bob'
 
-            feature_block_transformer.assert_called_once_with(metadata, 'test_bob')
+            feature_block_transformer.assert_called_once_with(runner_context, metadata, 'test_bob')
             1 * feature_block_transformer.return_value.visit(node.body[0].body[1])
 
             feature_block_rule_enforcer.assert_called_once_with(metadata, 'test_bob', node.body[0].body[1])
@@ -71,6 +74,7 @@ class JSpec:
     @mock.patch('nimoy.ast_tools.features.FeatureBlockTransformer')
     def a_feature_with_where_block_was_added(self, feature_block_transformer, feature_block_rule_enforcer):
         with setup:
+            runner_context = RunnerContext()
             module_definition = """
 class JSpec:
     def test_jim(self):
@@ -90,13 +94,13 @@ class JSpec:
             feature_block_transformer.return_value.visit.side_effect = visit
 
         with when:
-            FeatureRegistrationTransformer(Location('some_spec.py'), metadata).visit(node)
+            FeatureRegistrationTransformer(runner_context, Location('some_spec.py'), metadata).visit(node)
 
         with then:
             len(metadata.features) == 1
             metadata.features[0] == 'test_jim'
 
-            feature_block_transformer.assert_called_once_with(metadata, 'test_jim')
+            feature_block_transformer.assert_called_once_with(runner_context, metadata, 'test_jim')
             feature_block_transformer.return_value.visit.assert_called_once_with(node.body[0].body[0])
 
             feature_block_rule_enforcer.assert_called_once_with(metadata, 'test_jim', node.body[0].body[0])

--- a/specs/nimoy/ast_tools/specs_spec.py
+++ b/specs/nimoy/ast_tools/specs_spec.py
@@ -2,6 +2,7 @@ import ast
 from unittest import mock
 
 from nimoy.ast_tools.specs import SpecTransformer
+from nimoy.runner.metadata import RunnerContext
 from nimoy.runner.spec_finder import Location
 from nimoy.specification import Specification
 
@@ -27,7 +28,7 @@ class Bobson:
         found_metadata = []
 
         with when:
-            SpecTransformer(Location('some_spec.py'), found_metadata).visit(node)
+            SpecTransformer(RunnerContext(), Location('some_spec.py'), found_metadata).visit(node)
 
         with then:
             len(found_metadata) == 2
@@ -53,7 +54,7 @@ class JonesSpec(Specification):
         found_metadata = []
 
         with when:
-            SpecTransformer(Location('some_spec.py::JonesSpec'), found_metadata).visit(node)
+            SpecTransformer(RunnerContext(), Location('some_spec.py::JonesSpec'), found_metadata).visit(node)
 
         with then:
             len(found_metadata) == 1

--- a/specs/nimoy/integration/specs_integration_spec.py
+++ b/specs/nimoy/integration/specs_integration_spec.py
@@ -1,6 +1,7 @@
 import ast
 
 from nimoy.ast_tools.specs import SpecTransformer
+from nimoy.runner.metadata import RunnerContext
 from nimoy.runner.spec_finder import Location
 from nimoy.specification import Specification
 
@@ -27,7 +28,7 @@ class JimbobSpec(Specification):
 
         with when:
             found_metadata = []
-            SpecTransformer(Location('some_spec.py'), found_metadata).visit(node)
+            SpecTransformer(RunnerContext(), Location('some_spec.py'), found_metadata).visit(node)
         with then:
             len(node.body[1].body) == 2  # The where method should have been extracted to class level
             node.body[1].body[1].name == 'my_feature_where'

--- a/specs/nimoy/runner/specification_loader_spec.py
+++ b/specs/nimoy/runner/specification_loader_spec.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from nimoy.ast_tools.ast_metadata import SpecMetadata
+from nimoy.runner.metadata import RunnerContext
 from nimoy.runner.spec_finder import Location
 from nimoy.runner.spec_loader import SpecLoader
 from nimoy.specification import Specification
@@ -15,7 +16,7 @@ class SpecificationLoaderSpec(Specification):
             ast_chain.apply.return_value = [metadata]
 
         with when:
-            returned_spec_metadata = SpecLoader(ast_chain).load(
+            returned_spec_metadata = SpecLoader(RunnerContext(), ast_chain).load(
                 [(Location('/path/to/spec.py'), 'class Jimbob:\n    pass')])
 
         with then:

--- a/specs/nimoy/runner_helper.py
+++ b/specs/nimoy/runner_helper.py
@@ -1,5 +1,6 @@
 from io import StringIO
 
+from nimoy.runner.metadata import RunnerContext
 from nimoy.runner.spec_finder import Location
 from nimoy.runner.unittest_execution_framework import UnitTestExecutionFramework
 from nimoy.spec_runner import SpecRunner
@@ -8,4 +9,5 @@ from nimoy.spec_runner import SpecRunner
 def run_spec_contents(spec_contents):
     str_io = StringIO()
     execution_framework = UnitTestExecutionFramework(stream=str_io)
-    return SpecRunner._run_on_contents(execution_framework, [(Location('/fake/path.py'), spec_contents)])
+    return SpecRunner._run_on_contents(RunnerContext(), execution_framework,
+                                       [(Location('/fake/path.py'), spec_contents)])

--- a/specs/nimoy/specification_spec.py
+++ b/specs/nimoy/specification_spec.py
@@ -25,6 +25,12 @@ class FeatureBlockRuleEnforcerSpec(Specification):
 
 
 class InternalSpecificationMethodsSpec(Specification):
+
+    # By default the unittest mock fails when a mocked method begins with the string "assert" or "assret"
+    @staticmethod
+    def _mark_mock_as_unsafe(m):
+        m.return_value._mock_unsafe = True
+
     def feature_block_context_is_returned(self):
         with given:
             class SomeSpec(Specification):
@@ -51,10 +57,24 @@ class InternalSpecificationMethodsSpec(Specification):
         with then:
             1 * compare_mock.return_value.compare('a', 'b', 'some_name')
 
+    @mock.patch('nimoy.specification.PowerAssertions')
+    def internal_power_assertion_is_called(self, power_assert_mock):
+        with given:
+            InternalSpecificationMethodsSpec._mark_mock_as_unsafe(power_assert_mock)
+
+            class SomeSpec(Specification):
+                pass
+
+        with when:
+            SomeSpec()._power_assert({'a': 'b'})
+
+        with then:
+            1 * power_assert_mock.return_value.assert_and_raise({'a': 'b'})
+
     @mock.patch('nimoy.specification.MockAssertions')
     def internal_mock_assertion_is_performed(self, mock_assertions_mock):
         with given:
-            mock_assertions_mock.return_value._mock_unsafe = True
+            InternalSpecificationMethodsSpec._mark_mock_as_unsafe(mock_assertions_mock)
 
             class SomeSpec(Specification):
                 pass
@@ -71,7 +91,7 @@ class InternalSpecificationMethodsSpec(Specification):
     @mock.patch('nimoy.specification.ExceptionAssertions')
     def internal_exception_assertion_is_performed(self, exception_assertions_mock):
         with given:
-            exception_assertions_mock.return_value._mock_unsafe = True
+            InternalSpecificationMethodsSpec._mark_mock_as_unsafe(exception_assertions_mock)
 
             class SomeSpec(Specification):
                 pass


### PR DESCRIPTION
Adding a basic power assertion capability.

This PR introduces 2 new classes that represent parts of an assertion expression - `Expression` and `Op`.
Assertion expressions like `my_var.my_field == my_var_2` will be AST transformed to a structure made out of these 2 classes, where `my_var` is an `Expression` and `==` is an `Op`.
 
Also in this PR is the `PowerAssertions` class that will then render the transformed expressions to something like:
```
my_var.my_field == my_var_2
|      |        |  |
|      |        |  {'bob': 'mcbob'}
|      2        false
{'moo': 'bob'}
````